### PR TITLE
[fix] normalize by K[2, 2] when decomposing P

### DIFF
--- a/camtools/convert.py
+++ b/camtools/convert.py
@@ -342,6 +342,7 @@ def P_to_K_R_t(P):
     ) = cv2.decomposeProjectionMatrix(P)
 
     K = camera_matrix
+    K = K / K[2, 2]
     R = rot_matrix
     t = -rot_matrix @ (trans_vect[:3] / trans_vect[3])
 


### PR DESCRIPTION
Such that `K` follows the standard OpenCV convention.