### PR TITLE
feat: up triangle, point-plane distance, exact camera size

### DIFF
--- a/camtools/sanity.py
+++ b/camtools/sanity.py
@@ -65,6 +65,20 @@ def assert_shape(x, shape, name=None):
         raise ValueError(f"{name_must} has shape {shape}, but got shape {x.shape}.")
 
 
+def assert_shape_ndim(x, ndim, name=None):
+    """
+    Assert that x is a tensor with nd dimensions.
+
+    Args:
+        x: tensor
+        nd: number of dimensions
+        name: name of tensor
+    """
+    if x.ndim != ndim:
+        name_must = f"{name} must" if name is not None else "Must"
+        raise ValueError(f"{name_must} have {ndim} dimensions, but got {x.ndim}.")
+
+
 def assert_shape_nx3(x, name=None):
     assert_shape(x, (None, 3), name=name)
 
@@ -79,6 +93,10 @@ def assert_shape_4x4(x, name=None):
 
 def assert_shape_3x4(x, name=None):
     assert_shape(x, (3, 4), name=name)
+
+
+def assert_shape_3x3(x, name=None):
+    assert_shape(x, (3, 3), name=name)
 
 
 def assert_shape_3(x, name=None):

--- a/camtools/solver.py
+++ b/camtools/solver.py
@@ -150,3 +150,33 @@ def closest_points_of_line_pairs(src_os, src_ds, dst_os, dst_ds):
     dst_ps = dst_os + dst_ts.reshape((-1, 1)) * dst_ds
 
     return src_ps, dst_ps
+
+
+def point_plane_distance_three_points(point, plane_points):
+    """
+    Compute the distance between a point and a plane defined by three points.
+
+    Args:
+        point: (3,), point
+        plane_points: (3, 3), three points on the plane
+    """
+    if isinstance(point, list):
+        point = np.array(point)
+    if isinstance(plane_points, list):
+        plane_points = np.array(plane_points)
+
+    sanity.assert_shape_3(point, name="point")
+    sanity.assert_shape_3x3(plane_points, name="plane_points")
+
+    plane_a, plane_b, plane_c = plane_points
+
+    # Compute the normal vector of the plane.
+    plane_ab = plane_b - plane_a
+    plane_ac = plane_c - plane_a
+    plane_n = np.cross(plane_ab, plane_ac)
+    plane_n = plane_n / np.linalg.norm(plane_n)
+
+    # Compute the distance between the point and the plane.
+    # Ref: https://mathworld.wolfram.com/Point-PlaneDistance.html
+    distance = np.abs(np.dot(plane_n, point - plane_a))
+    return distance

--- a/test/test_solver.py
+++ b/test/test_solver.py
@@ -1,0 +1,17 @@
+import numpy as np
+import camtools as ct
+
+np.set_printoptions(formatter={"float": "{: 0.2f}".format})
+
+
+def test_point_plane_distance_three_points():
+    point = np.array([0, 0, 0])
+
+    plane_points = np.array([[1, 1, 0], [0, 1, 0], [0, 1, 1]])
+    ref_dist = 1.0
+    dist = ct.solver.point_plane_distance_three_points(point, plane_points)
+    np.testing.assert_allclose(dist, ref_dist)
+
+    plane_points = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    ref_dist = 1 / np.sqrt(3)
+    dist = ct.solver.point_plane_distance_three_points(point, plane_points)


### PR DESCRIPTION
## Notes on API change after this PR:
`disable_up_triangle=False` has been replaced by `up_triangle=True` in the new API.

## Up triangle
Now, we draw the "up triangle" by default, similar to Blender. The up direction is the negative Y direction per OpenCV convention. You may set `disable_up_triangle=True` to suppress drawing the up triangle.
<img src="https://github.com/yxlao/camtools/assets/1501945/be2b1715-fc0e-4060-a647-db430f0510c0 " height="240">

## Absolute camera scale
The camera frame now has an absolute scale, defined by the distance from the camera center to the visualized image plane. E.g., if you set the size to 1, you will get a camera frame where the distance between its camera center and the visualized image plane is 1. 
<img src="https://github.com/yxlao/camtools/assets/1501945/989e5f11-d6a4-42f2-9bcf-011ef37d65b5" height="240">

## Image width/height for camera plotter
Now, we support specifying `image_wh` when plotting camera frames. This is useful when the camera center is not exactly at the center of the image plane. 

## Point to plane distance
Now we can compute point-to-plane distance, where the plane is represented by 3 points. See `ct.solver.point_plane_distance_three_points()`.