### PR TITLE
[Refactor] Refactor to ct.transform.transform_points

### DIFF
--- a/camtools/__init__.py
+++ b/camtools/__init__.py
@@ -13,6 +13,7 @@ from . import raycast
 from . import sanity
 from . import solver
 from . import stat
+from . import transform
 
 import pkg_resources
 

--- a/camtools/normalize.py
+++ b/camtools/normalize.py
@@ -13,7 +13,7 @@ def compute_normalize_mat(points):
         You can check the correctness of compute_normalize_mat by:
         ```python
         normalize_mat = ct.normalize.compute_normalize_mat(points)
-        points_normalized = ct.project.homo_project(points, normalize_mat)
+        points_normalized = ct.transform.transform_points(points, normalize_mat)
         ct.stat.report_points_range(points_normalized)
         ```
 
@@ -22,7 +22,7 @@ def compute_normalize_mat(points):
         ```python
         K_new = K
         C = ct.convert.T_to_C(T)
-        C_new = ct.project.homo_project(C.reshape((-1, 3)), normalize_mat).flatten()
+        C_new = ct.transform.transform_points(C.reshape((-1, 3)), normalize_mat).flatten()
         pose_new = np.linalg.inv(T)
         pose_new[:3, 3] = C_new
         T_new = np.linalg.inv(pose_new)

--- a/camtools/project.py
+++ b/camtools/project.py
@@ -1,26 +1,11 @@
+"""
+Functions for projecting 2D->3D or 3D->2D.
+"""
+
 import numpy as np
 import torch
 from . import sanity
 from . import convert
-
-
-def homo_project(points, mat):
-    sanity.assert_shape_nx3(points, name="points")
-    sanity.assert_shape_4x4(mat, name="mat")
-    sanity.assert_same_device(points, mat)
-
-    N = len(points)
-    if torch.is_tensor(mat):
-        ones = torch.ones((N, 1), dtype=points.dtype, device=points.device)
-        points_homo = torch.hstack((points, ones))
-    else:
-        ones = np.ones((N, 1))
-        points_homo = np.hstack((points, ones))
-
-    # (mat @ points_homo.T).T
-    points_out = points_homo @ mat.T
-    points_out = points_out[:, :3] / points_out[:, 3:]
-    return points_out
 
 
 def points_to_pixel(points, K, T):

--- a/camtools/transform.py
+++ b/camtools/transform.py
@@ -1,0 +1,36 @@
+"""
+Functions for transforming points in 3D space.
+"""
+
+import numpy as np
+import torch
+from . import sanity
+
+
+def transform_points(points, transform_mat):
+    """
+    Transform points by a 4x4 matrix via homogenous coordinates projection.
+
+    Args:
+        points: (N, 3) array.
+        mat: (4, 4) array, the transformation matrix.
+
+    Returns:
+        (N, 3) array, the transformed points.
+    """
+    sanity.assert_shape_nx3(points, name="points")
+    sanity.assert_shape_4x4(transform_mat, name="mat")
+    sanity.assert_same_device(points, transform_mat)
+
+    N = len(points)
+    if torch.is_tensor(transform_mat):
+        ones = torch.ones((N, 1), dtype=points.dtype, device=points.device)
+        points_homo = torch.hstack((points, ones))
+    else:
+        ones = np.ones((N, 1))
+        points_homo = np.hstack((points, ones))
+
+    # (mat @ points_homo.T).T
+    points_out = points_homo @ transform_mat.T
+    points_out = points_out[:, :3] / points_out[:, 3:]
+    return points_out


### PR DESCRIPTION
**API breaking change**

- Rename `ct.project.homo_project` -> `ct.transform.transform_points`
- `ct.project` is now specifically reserved for 2D -> 3D or 3D -> 2D projections.
- `ct.transform` is now reserved for transformations (you can still call projections) in 3D space.