### PR TITLE
new: command line tool for compressing images `ct compress-images`

### DIFF
--- a/camtools/__init__.py
+++ b/camtools/__init__.py
@@ -12,6 +12,7 @@ from . import raycast
 from . import sanity
 from . import solver
 from . import transform
+from . import utility
 
 import pkg_resources
 

--- a/camtools/io.py
+++ b/camtools/io.py
@@ -4,7 +4,15 @@ import numpy as np
 from pathlib import Path
 
 
-def imwrite(im_path, im):
+def is_jpg_path(path):
+    return Path(path).suffix.lower() in [".jpg", ".jpeg"]
+
+
+def is_png_path(path):
+    return Path(path).suffix.lower() in [".png"]
+
+
+def imwrite(im_path, im, quality: int = 95):
     """
     Write image, with no surprises.
 
@@ -15,6 +23,7 @@ def imwrite(im_path, im):
         im: Numpy array.
             - ndims: Must be 1 or 3. Otherwise, an exception will be thrown.
             - dtype: Must be uint8, float32, float64.
+        quality: Quality of the output JPEG image, 1-100. Default is 95.
 
     Notes:
         - You should not use this to save a depth image (typically uint16).
@@ -22,7 +31,9 @@ def imwrite(im_path, im):
     """
     im_path = Path(im_path)
 
-    assert im_path.suffix in (".jpg", ".png")
+    assert is_jpg_path(im_path) or is_png_path(
+        im_path
+    ), f"{im_path} is not a JPG or PNG file."
     assert isinstance(im, np.ndarray)
     assert im.ndim in (1, 3)
     assert im.dtype in [np.uint8, np.float32, np.float64]
@@ -47,7 +58,10 @@ def imwrite(im_path, im):
     # Write.
     im_dir = im_path.parent
     im_dir.mkdir(parents=True, exist_ok=True)
-    cv2.imwrite(str(im_path), im)
+    if is_jpg_path(im_path):
+        cv2.imwrite(str(im_path), im, [cv2.IMWRITE_JPEG_QUALITY, quality])
+    else:
+        cv2.imwrite(str(im_path), im)
 
 
 def imwrite_depth(im_path, im, depth_scale=1000.0):
@@ -76,7 +90,7 @@ def imwrite_depth(im_path, im, depth_scale=1000.0):
     """
     im_path = Path(im_path)
 
-    assert im_path.suffix == ".png"
+    assert is_png_path(im_path), f"{im_path} is not a PNG file."
     assert isinstance(im, np.ndarray)
     assert im.dtype in [np.float32, np.float64]
     assert im.ndim == 2
@@ -117,7 +131,9 @@ def imread(im_path, alpha_mode=None):
         - If image dtype is uint16, an exception will be thrown.
     """
     im_path = Path(im_path)
-    assert im_path.suffix in (".jpg", ".png")
+    assert is_jpg_path(im_path) or is_png_path(
+        im_path
+    ), f"{im_path} is not a JPG or PNG file."
     assert im_path.is_file(), f"{im_path} is not a file."
 
     # Read.
@@ -215,7 +231,7 @@ def imread_depth(im_path, depth_scale=1000.0):
         practice is to use 0 as invalid depth.
     """
     im_path = Path(im_path)
-    assert im_path.suffix == ".png"
+    assert is_png_path(im_path), f"{im_path} is not a PNG file."
     assert im_path.is_file(), f"{im_path} is not a file."
 
     im = cv2.imread(str(im_path), cv2.IMREAD_UNCHANGED)

--- a/camtools/tools/__init__.py
+++ b/camtools/tools/__init__.py
@@ -1,2 +1,3 @@
 from . import crop_boarders
 from . import draw_bboxes
+from . import compress_images

--- a/camtools/tools/cli.py
+++ b/camtools/tools/cli.py
@@ -37,7 +37,7 @@ def main():
     sub_parser = ct.tools.crop_boarders.instantiate_parser(sub_parser)
     sub_parser.set_defaults(func=ct.tools.crop_boarders.entry_point)
 
-    # ct draw-bboxes a.png b.png
+    # ct draw-bboxes
     sub_parser = sub_parsers.add_parser(
         "draw-bboxes",
         help="Draw bounding boxes on images.\n"
@@ -49,6 +49,19 @@ def main():
     )
     sub_parser = ct.tools.draw_bboxes.instantiate_parser(sub_parser)
     sub_parser.set_defaults(func=ct.tools.draw_bboxes.entry_point)
+
+    # ct compress-images
+    sub_parser = sub_parsers.add_parser(
+        "compress-images",
+        help="Compress images (PNGs will be converted to JPGs)\n"
+        "```\n"
+        "ct compress-images *.png --quality 80\n"
+        "ct compress-images -r images --quality 80 --inplace\n"
+        "```",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    sub_parser = ct.tools.compress_images.instantiate_parser(sub_parser)
+    sub_parser.set_defaults(func=ct.tools.compress_images.entry_point)
 
     args = main_parser.parse_args()
     if args.subcommand in sub_parsers.choices.keys():

--- a/camtools/tools/cli.py
+++ b/camtools/tools/cli.py
@@ -53,10 +53,11 @@ def main():
     # ct compress-images
     sub_parser = sub_parsers.add_parser(
         "compress-images",
-        help="Compress images (PNGs will be converted to JPGs)\n"
+        help="Compress images (png will also be converted to jpg)\n"
         "```\n"
         "ct compress-images *.png --quality 80\n"
-        "ct compress-images -r images --quality 80 --inplace\n"
+        "ct compress-images image_dir --quality 80 --inplace\n"
+        "ct compress-images ~/paper/my-paper/figures -i -u ~/paper/my-paper/\n"
         "```",
         formatter_class=argparse.RawTextHelpFormatter,
     )

--- a/camtools/tools/compress_images.py
+++ b/camtools/tools/compress_images.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import camtools as ct
 import os
 import tempfile
+import json
 
 
 def instantiate_parser(parser):
@@ -176,3 +177,19 @@ def compress_images(
         f"{src_total_size_mb:.2f} MB -> {dst_total_size_mb:.2f} MB "
         f"(compression ratio: {compression_ratio:.2f})"
     )
+
+    # Write log.
+    # This can be used to rename paths in texts such as Tex or Markdown.
+    # Json file is a list of dicts.
+    json_path = Path(tempfile.gettempdir()) / "compress_images_log.json"
+    json_data = []
+    for src_path, dst_path in zip(src_paths, dst_paths):
+        json_data.append(
+            {
+                "src_path": str(src_path),
+                "dst_path": str(dst_path),
+            }
+        )
+    with open(json_path, "w") as fp:
+        json.dump(json_data, fp, indent=4)
+    print(f"Log written to {json_path}")

--- a/camtools/tools/compress_images.py
+++ b/camtools/tools/compress_images.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+import argparse
+import numpy as np
+import cv2
+import camtools as ct
+import os
+
+
+def instantiate_parser(parser):
+    parser.add_argument(
+        "input",
+        type=Path,
+        help="One or more image path(s), or one directory. Supporting PNG and JPG.",
+        nargs="+",
+    )
+    parser.add_argument(
+        "--inplace",
+        "-i",
+        action="store_true",
+        help="If specified, the original file will be deleted, even for PNG->JPG case.",
+    )
+    parser.add_argument(
+        "--quality",
+        type=int,
+        default=80,
+        help="Quality of the output JPEG image, 1-100. Default is 80.",
+    )
+    return parser
+
+
+def entry_point(parser, args):
+    """
+    This is used by sub_parser.set_defaults(func=entry_point).
+    The parser argument is not used.
+    """
+    # Collect all src_paths.
+    src_paths = []
+    if len(args.input) == 1 and args.input[0].is_dir():
+        src_dir = args.input[0]
+        src_paths += list(src_dir.glob("**/*"))
+    else:
+        src_paths += args.input
+    src_paths = [
+        path for path in src_paths if ct.io.is_jpg_path(path) or ct.io.is_png_path(path)
+    ]
+    src_paths = [path.resolve().absolute() for path in src_paths]
+    missing_paths = [path for path in src_paths if not path.is_file()]
+    if not src_paths:
+        raise ValueError("No image found.")
+    if missing_paths:
+        raise ValueError(f"Missing files: {missing_paths}")
+
+    # Compute dst_paths.
+    dst_paths = []
+    for src_path in src_paths:
+        if args.inplace:
+            if ct.io.is_jpg_path(src_path):
+                dst_paths.append(src_path)
+            elif ct.io.is_png_path(src_path):
+                dst_paths.append(src_path.with_suffix(".jpg"))
+            else:
+                raise ValueError(f"Unsupported image type: {src_path}")
+        else:
+            if ct.io.is_jpg_path(src_path):
+                dst_paths.append(src_path.parent / f"compressed_{src_path.name}")
+            elif ct.io.is_png_path(src_path):
+                dst_paths.append(src_path.parent / f"compressed_{src_path.name}.jpg")
+            else:
+                raise ValueError(f"Unsupported image type: {src_path}")
+
+    # Print summary.
+    pwd = Path.cwd().resolve().absolute()
+    print(f"[Files]")
+    for src_path, dst_path in zip(src_paths, dst_paths):
+        print(f"  - src: {Path(os.path.relpath(path=src_path, start=pwd))}")
+        print(f"    dst: {Path(os.path.relpath(path=dst_path, start=pwd))}")
+    print(f"[Configs]")
+    inplace_str = "src will be deleted" if args.inplace else "src will be kept"
+    print(f"  - inplace: {inplace_str}")
+    print(f"  - quality: {args.quality}")
+
+    # Confirm.
+    if ct.utility.query_yes_no("Proceed?", default=False):
+        print("Proceeding.")
+    else:
+        print("Aborted.")
+        return 0

--- a/camtools/tools/compress_images.py
+++ b/camtools/tools/compress_images.py
@@ -25,6 +25,12 @@ def instantiate_parser(parser):
         default=95,
         help="Quality of the output JPEG image, 1-100. Default is 95.",
     )
+    parser.add_argument(
+        "--update_texts_in_dir",
+        "-u",
+        type=Path,
+        help="Update text files (.txt, .md, .tex) in the directory to reflect the new image paths.",
+    )
     return parser
 
 
@@ -61,17 +67,35 @@ def entry_point(parser, args):
             dst_path = dst_path.parent / f"compressed_{dst_path.name}"
         dst_paths.append(dst_path)
 
+    # Check update_texts_in_dir.
+    if args.update_texts_in_dir is not None:
+        update_texts_in_dir = Path(args.update_texts_in_dir)
+        if not update_texts_in_dir.is_dir():
+            raise ValueError(
+                f"update_texts_in_dir must be a directory, "
+                f"but got {update_texts_in_dir}"
+            )
+        text_paths = get_all_text_paths(update_texts_in_dir)
+
     # Print summary.
     pwd = Path.cwd().resolve().absolute()
     print(f"[Files]")
     for src_path, dst_path in zip(src_paths, dst_paths):
         print(f"  - src: {Path(os.path.relpath(path=src_path, start=pwd))}")
         print(f"    dst: {Path(os.path.relpath(path=dst_path, start=pwd))}")
-    print(f"[Configs]")
+    print(f"[To be updated]")
     inplace_str = "src will be deleted" if args.inplace else "src will be kept"
-    print(f"  - num_images: {len(src_paths)}")
-    print(f"  -    quality: {args.quality}")
-    print(f"  -    inplace: {inplace_str}")
+    if args.update_texts_in_dir is not None:
+        print(f"  -         num_images: {len(src_paths)} files")
+        print(f"  -            quality: {args.quality}")
+        print(f"  -            inplace: {inplace_str}")
+        print(
+            f"  - update_texts_in_dir: {update_texts_in_dir} ({len(text_paths)} files)"
+        )
+    else:
+        print(f"  - num_images: {len(src_paths)} files")
+        print(f"  -    quality: {args.quality}")
+        print(f"  -    inplace: {inplace_str}")
 
     # Confirm.
     if ct.utility.query_yes_no("Proceed?", default=False):
@@ -80,6 +104,7 @@ def entry_point(parser, args):
             dst_paths=dst_paths,
             quality=args.quality,
             delete_src=args.inplace,
+            update_texts_in_dir=update_texts_in_dir,
         )
     else:
         print("Aborted.")
@@ -139,11 +164,43 @@ def compress_image_and_return_sizes(
     return src_size, dst_size
 
 
+def get_all_text_paths(root_dir):
+    def is_text_file(path):
+        return path.is_file() and path.suffix in [".txt", ".md", ".tex"]
+
+    root_dir = Path(root_dir)
+    text_paths = list(root_dir.glob("**/*"))
+    text_paths = [text_path for text_path in text_paths if is_text_file(text_path)]
+    return text_paths
+
+
+def replace_strings_in_file(path, replace_dict):
+    """
+    Replace strings in a file.
+
+    Args:
+        path: Path to the file.
+        replace_dict: A dictionary of strings to be replaced.
+            - Keys are the strings to be replaced.
+            - Values are the strings to replace with.
+    """
+    with path.open() as f:
+        lines = f.readlines()
+    lines = [line.rstrip() for line in lines]
+    for i, line in enumerate(lines):
+        for src_str, dst_str in replace_dict.items():
+            lines[i] = lines[i].replace(src_str, dst_str)
+    with path.open("w") as f:
+        for line in lines:
+            f.write(f"{line}\n")
+
+
 def compress_images(
     src_paths,
     dst_paths,
     quality: int = 95,
     delete_src: bool = False,
+    update_texts_in_dir: Path = None,
 ):
     """
     Compress images (PNGs will be converted to JPGs)
@@ -153,6 +210,8 @@ def compress_images(
         dst_paths: List of destination image paths.
         quality: Quality of the output JPEG image, 1-100. Default is 95.
         delete_src: If True, the src_path will be deleted.
+        update_texts_in_dir: If not None, all text files in the directory
+            will be updated to reflect the new image paths.
     """
 
     src_sizes = []
@@ -178,18 +237,45 @@ def compress_images(
         f"(compression ratio: {compression_ratio:.2f})"
     )
 
-    # Write log.
-    # This can be used to rename paths in texts such as Tex or Markdown.
-    # Json file is a list of dicts.
-    json_path = Path(tempfile.gettempdir()) / "compress_images_log.json"
-    json_data = []
-    for src_path, dst_path in zip(src_paths, dst_paths):
-        json_data.append(
-            {
-                "src_path": str(src_path),
-                "dst_path": str(dst_path),
-            }
-        )
-    with open(json_path, "w") as fp:
-        json.dump(json_data, fp, indent=4)
-    print(f"Log written to {json_path}")
+    if update_texts_in_dir is not None:
+        # Collect all text paths.
+        root_dir = update_texts_in_dir.resolve().absolute()
+        text_paths = get_all_text_paths(root_dir)
+        print(f"[Updating {len(text_paths)} text files]")
+        for text_path in text_paths:
+            print(f"  - {text_path}")
+
+        # Print update dict.
+        replace_dict = {}
+        for src_path, dst_path in zip(src_paths, dst_paths):
+            src_path = src_path.relative_to(root_dir)
+            dst_path = dst_path.relative_to(root_dir)
+            replace_dict[str(src_path)] = str(dst_path)
+        keys = sorted(replace_dict.keys())
+        print(f"[With replace dict of {len(keys)} patterns]")
+        for key in keys:
+            print(f"  - {key} -> {replace_dict[key]}")
+
+        prompt = "Continue?"
+        if ct.utility.query_yes_no(prompt, default=False):
+            pass
+        else:
+            print("Aborted.")
+            return 0
+
+        same_paths = []
+        updated_paths = []
+        for text_path in text_paths:
+            before_text = text_path.read_text()
+            replace_strings_in_file(path=text_path, replace_dict=replace_dict)
+            after_text = text_path.read_text()
+            if before_text == after_text:
+                same_paths.append(text_path)
+            else:
+                updated_paths.append(text_path)
+
+        print(f"[Summary]")
+        print(f"  - num_same   : {len(same_paths)}")
+        print(f"  - num_updated: {len(updated_paths)}")
+        for text_path in updated_paths:
+            print(f"    - {text_path}")

--- a/camtools/tools/compress_images.py
+++ b/camtools/tools/compress_images.py
@@ -21,6 +21,7 @@ def instantiate_parser(parser):
     )
     parser.add_argument(
         "--quality",
+        "-q",
         type=int,
         default=80,
         help="Quality of the output JPEG image, 1-100. Default is 80.",

--- a/camtools/utility.py
+++ b/camtools/utility.py
@@ -1,0 +1,49 @@
+import sys
+
+
+def query_yes_no(question, default=None):
+    """Ask a yes/no question via raw_input() and return their answer.
+
+    Args:
+        question: A string that is presented to the user.
+        default: The presumed answer if the user just hits <Enter>.
+            - True: The answer is assumed to be yes.
+            - False: The answer is assumed to be no.
+            - None: The answer is required from the user.
+
+    Returns:
+        Returns True for "yes" or False for "no".
+
+    Examples:
+        if query_yes_no("Continue?", default="yes"):
+            print("Proceeding.")
+        else:
+            print("Aborted.")
+    """
+    if default is None:
+        prompt = "[y/n]"
+    elif default == True:
+        prompt = "[Y/n]"
+    elif default == False:
+        prompt = "[y/N]"
+    else:
+        raise ValueError(f"Invalid default answer: '{default}'")
+
+    response_to_bool = {
+        "yes": True,
+        "y": True,
+        "ye": True,
+        "no": False,
+        "n": False,
+        True: True,
+        False: False,
+    }
+    while True:
+        print(f"{question} {prompt} ", end="")
+        choice = input().lower()
+        if default is not None and choice == "":
+            return response_to_bool[default]
+        elif choice in response_to_bool:
+            return response_to_bool[choice]
+        else:
+            print('Please respond with "yes" or "no" (or "y" or "n").')

--- a/camtools/utility.py
+++ b/camtools/utility.py
@@ -1,6 +1,3 @@
-import sys
-
-
 def query_yes_no(question, default=None):
     """Ask a yes/no question via raw_input() and return their answer.
 

--- a/camtools/utility.py
+++ b/camtools/utility.py
@@ -12,10 +12,19 @@ def query_yes_no(question, default=None):
         Returns True for "yes" or False for "no".
 
     Examples:
+        ```python
         if query_yes_no("Continue?", default="yes"):
             print("Proceeding.")
         else:
             print("Aborted.")
+        ```
+
+        ```python
+        if not query_yes_no("Continue?", default="yes"):
+            print("Aborted.")
+            return  # Or exit(0)
+        print("Proceeding.")
+        ```
     """
     if default is None:
         prompt = "[y/n]"


### PR DESCRIPTION
## Features
- Compress jpg to the specified quality (default: 95), convert png to jpg
- Update text paths given the root directory to reflect the new image paths

TLDR:

```bash
# Compress images in-place, and update text files (e.g, .tex) to reflect the new image paths
ct compress-images ~/paper/my-paper/figures -i -u ~/paper/my-paper/
```

## Usage

```bash
# Compress images by specifying image names.
# The compressed image will have a prefix "compressed_".
ct compress-images a.png b.png c.jpg

# Compress images in-place.
# The original images will be deleted, even if a .png file is converted to .jpg.
ct compress-images a.png b.png c.jpg -i

# Compress images in the current directory, recursively.
ct compress-images .

# Compress images with -i (in-place) and -q (quality) options.
# The default quality is 95.
ct compress-images . -i -q 95

# Compress images and update text files within the root path
# This is the original purpose of this PR.
ct compress-images ~/paper/my-paper/figures --inplace --update_texts_in_dir ~/paper/my-paper/
```

## Changes

- fix(`io.py`): change imwrite function to accept quality parameter for JPEG images to allow customization of output quality
- feat(`cli.py`): add compress-images subcommand to the command-line interface to allow users to compress images
- feat(`compress_images.py`): add implementation for compress-images subcommand, including support for compressing PNG images to JPG format
- feat(`utility.py`): add query_yes_no function to provide a utility function for asking yes/no questions to the user
