### PR TITLE
fix: handle alpha pngs, avoid duplicated compression

### DIFF
--- a/camtools/tools/compress_images.py
+++ b/camtools/tools/compress_images.py
@@ -2,7 +2,6 @@ from pathlib import Path
 import camtools as ct
 import os
 import tempfile
-import json
 import shutil
 
 


### PR DESCRIPTION
- If `--flatten_alpha_channel` is specified, PNGs with alpha channel will be flattened. Otherwise, those PNGs will be skipped.
- Support minimum compression ratio for jpg->jpg compression, to avoid recompressing already compressed images