### PR TITLE
new: render geometries to image with custom camera parameters

### DIFF
--- a/camtools/__init__.py
+++ b/camtools/__init__.py
@@ -9,6 +9,7 @@ from . import metric
 from . import normalize
 from . import project
 from . import raycast
+from . import render
 from . import sanity
 from . import solver
 from . import transform

--- a/camtools/render.py
+++ b/camtools/render.py
@@ -13,6 +13,7 @@ def render_geometries(
     height: int = 720,
     width: int = 1280,
     visible: bool = False,
+    point_size: float = 1.0,
 ):
     """
     Render a mesh using Open3D legacy visualizer. This requires a display.
@@ -26,6 +27,7 @@ def render_geometries(
         height: int image height.
         width: int image width.
         visible: bool whether to show the window.
+        point_size: float point size for point cloud objects.
 
     Returns:
         image: (H, W, 3) float32 np.ndarray image.
@@ -52,7 +54,10 @@ def render_geometries(
         height=height,
         visible=visible,
     )
+
     for geometry in geometries:
+        if isinstance(geometry, o3d.geometry.PointCloud):
+            vis.get_render_option().point_size = point_size
         vis.add_geometry(geometry)
 
     if is_camera_provided:

--- a/camtools/render.py
+++ b/camtools/render.py
@@ -39,8 +39,6 @@ def render_geometries(
     """
     if not isinstance(geometries, list):
         raise TypeError("geometries must be a list of Open3D geometries.")
-
-    # Check camera.
     if K is None and T is not None:
         raise ValueError("K must be provided if T is provided.")
     elif K is not None and T is None:
@@ -126,8 +124,6 @@ def get_render_view_status_str(
     """
     if not isinstance(geometries, list):
         raise TypeError("geometries must be a list of Open3D geometries.")
-
-    # Check camera.
     if K is None and T is not None:
         raise ValueError("K must be provided if T is provided.")
     elif K is not None and T is None:

--- a/camtools/render.py
+++ b/camtools/render.py
@@ -1,4 +1,3 @@
-import copy
 from typing import List
 
 import numpy as np
@@ -18,7 +17,7 @@ def render_geometries(
     point_size: float = 1.0,
 ):
     """
-    Render a mesh using Open3D legacy visualizer. This function may require a display.
+    Render Open3D geometries to an image. This function may require a display.
 
     Args:
         mesh: Open3d TriangleMesh.
@@ -106,7 +105,7 @@ def get_render_view_status_str(
     width: int = 1280,
 ) -> str:
     """
-    Get a view status string for rendering using Open3D legacy visualizer. This is
+    Get a view status string for rendering with Open3D visualizer. This is
     useful for rendering multiple geometries with the same rendering camera.
     This function may require a display.
 

--- a/camtools/render.py
+++ b/camtools/render.py
@@ -1,0 +1,85 @@
+from typing import List
+
+import numpy as np
+import open3d as o3d
+
+from . import sanity
+
+
+def render_geometries(
+    geometries: List[o3d.geometry.Geometry3D],
+    K: np.ndarray = None,
+    T: np.ndarray = None,
+    height: int = 720,
+    width: int = 1280,
+    visible: bool = False,
+):
+    """
+    Render a mesh using Open3D legacy visualizer. This requires a display.
+
+    Args:
+        mesh: Open3d TriangleMesh.
+        K: (3, 3) np.ndarray camera intrinsic. If None, use Open3D's camera
+            inferred from the geometries. K must be provided if T is provided.
+        T: (4, 4) np.ndarray camera extrinsic. If None, use Open3D's camera
+            inferred from the geometries. T must be provided if K is provided.
+        height: int image height.
+        width: int image width.
+        visible: bool whether to show the window.
+
+    Returns:
+        image: (H, W, 3) float32 np.ndarray image.
+    """
+    if not isinstance(geometries, list):
+        raise TypeError("geometries must be a list of Open3D geometries.")
+
+    if K is None and T is None:
+        is_camera_provided = False
+    elif K is None and T is not None:
+        raise ValueError("K must be provided if T is provided.")
+    elif K is not None and T is None:
+        raise ValueError("T must be provided if K is provided.")
+    else:
+        is_camera_provided = True
+
+    if is_camera_provided:
+        sanity.assert_K(K)
+        sanity.assert_T(T)
+
+    vis = o3d.visualization.Visualizer()
+    vis.create_window(
+        width=width,
+        height=height,
+        visible=visible,
+    )
+    for geometry in geometries:
+        vis.add_geometry(geometry)
+
+    if is_camera_provided:
+        o3d_intrinsic = o3d.camera.PinholeCameraIntrinsic(
+            width=width,
+            height=height,
+            fx=K[0, 0],
+            fy=K[1, 1],
+            cx=K[0, 2],
+            cy=K[1, 2],
+        )
+        o3d_extrinsic = T
+        o3d_camera = o3d.camera.PinholeCameraParameters()
+        o3d_camera.intrinsic = o3d_intrinsic
+        o3d_camera.extrinsic = o3d_extrinsic
+        ctr = vis.get_view_control()
+        ctr.convert_from_pinhole_camera_parameters(
+            o3d_camera,
+            allow_arbitrary=True,
+        )
+        for geometry in geometries:
+            vis.update_geometry(geometry)
+
+    vis.poll_events()
+    vis.update_renderer()
+    buffer = vis.capture_screen_float_buffer()
+    vis.destroy_window()
+    im_buffer = np.asarray(buffer)
+
+    return im_buffer


### PR DESCRIPTION
## Description

Add support for rendering geometries to an image with custom camera parameters.

1. `ct.render.render_geometries()`: A function to render a list of Open3D geometries objects into an image. It supports optional camera intrinsic (K), extrinsic (T), as well as width and height.
2. `ct.render.get_render_view_status_str()`: Obtain a view status string for consistent camera settings across multiple renders.

## Examples
```python
# Render with custom camera params and canvas size
im_render = render.render_geometries([pcd, mesh], K=K, T=T, width=800, height=600)

# Apply the rendering camera to render new geometries
view_status_str = render.get_render_view_status_str([pcd, mesh], K=K, T=T, width=800, height=600)
im_render_new = render.render_geometries([new_pcd, new_mesh], view_status_str=view_status_str, width=1920, height=1080)
```

## Note

You might need a windowing system with displays or compile Open3D in [headless mode](https://www.open3d.org/docs/latest/tutorial/Advanced/headless_rendering.html) for the rendering to work (or, for Open3D visualization to work in general). 