### PR TITLE
perf: more efficient ct crop-boarders --same_crop

### DIFF
--- a/camtools/tools/crop_boarders.py
+++ b/camtools/tools/crop_boarders.py
@@ -216,7 +216,7 @@ def entry_point(parser, args):
         ),
         desc="Saving images",
         total=num_ims,
-        enable=False,
+        disable=True,
     ):
         out_dir = dst_path.parent
         if not out_dir.exists():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "scikit-image>=0.16.2",
   "torch>=1.8.0",
   "lpips>=0.1.4",
+  "tqdm>=4.60.0",
 ]
 description = "CamTools: Camera Tools for Computer Vision."
 license = {text = "MIT"}


### PR DESCRIPTION
Now, we don't need to stack the images to compute croppings.