### PR TITLE
perf: faster cropping; parallel imread/crop; mt_loop and mp_loop helper functions

### DIFF
--- a/camtools/image.py
+++ b/camtools/image.py
@@ -20,7 +20,7 @@ def crop_white_boarders(im: np.array, padding: Tuple[int] = (0, 0, 0, 0)) -> np.
     return im_dst
 
 
-def compute_cropping(im: np.array) -> Tuple[int]:
+def compute_cropping_v1(im: np.array) -> Tuple[int]:
     """
     Compute top, bottom, left, right white boarder in pixels.
 
@@ -73,24 +73,13 @@ def compute_cropping(im: np.array) -> Tuple[int]:
         else:
             break
 
-    # call compute_cropping_v2 can compare results.
-    crop_t_v2, crop_b_v2, crop_l_v2, crop_r_v2 = compute_cropping_v2(im)
-    if (
-        crop_t != crop_t_v2
-        or crop_b != crop_b_v2
-        or crop_l != crop_l_v2
-        or crop_r != crop_r_v2
-    ):
-        raise ValueError(
-            f"compute_cropping_v2 failed to compute the correct cropping: "
-            f"({crop_t}, {crop_b}, {crop_l}, {crop_r}) != "
-            f"({crop_t_v2}, {crop_b_v2}, {crop_l_v2}, {crop_r_v2})"
-        )
-
     return crop_t, crop_b, crop_l, crop_r
 
 
-def compute_cropping_v2(im: np.ndarray) -> Tuple[int, int, int, int]:
+def compute_cropping(
+    im: np.ndarray,
+    check_with_v1=False,
+) -> Tuple[int, int, int, int]:
     """
     Compute top, bottom, left, right white borders in pixels for a 3-channel
     image.
@@ -123,6 +112,21 @@ def compute_cropping_v2(im: np.ndarray) -> Tuple[int, int, int, int]:
     crop_b = im.shape[0] - rows_with_color[-1] - 1 if len(rows_with_color) else 0
     crop_l = cols_with_color[0] if len(cols_with_color) else 0
     crop_r = im.shape[1] - cols_with_color[-1] - 1 if len(cols_with_color) else 0
+
+    # Check the results against compute_cropping_v1 if requested
+    if check_with_v1:
+        crop_t_v1, crop_b_v1, crop_l_v1, crop_r_v1 = compute_cropping_v1(im)
+        if (
+            crop_t != crop_t_v1
+            or crop_b != crop_b_v1
+            or crop_l != crop_l_v1
+            or crop_r != crop_r_v1
+        ):
+            raise ValueError(
+                f"compute_cropping_v1 failed to compute the correct cropping: "
+                f"({crop_t}, {crop_b}, {crop_l}, {crop_r}) != "
+                f"({crop_t_v1}, {crop_b_v1}, {crop_l_v1}, {crop_r_v1})"
+            )
 
     return crop_t, crop_b, crop_l, crop_r
 

--- a/camtools/tools/crop_boarders.py
+++ b/camtools/tools/crop_boarders.py
@@ -126,10 +126,9 @@ def entry_point(parser, args):
                 "All images must be of the same shape when --same_crop is " "specified."
             )
 
-        individual_croppings = [
-            ct.image.compute_cropping(im)
-            for im in tqdm(src_ims, desc="Computing croppings")
-        ]
+        individual_croppings = ct.utility.mt_loop(ct.image.compute_cropping, src_ims)
+
+        # Compute the minimum cropping boarders.
         min_crop_u, min_crop_d, min_crop_l, min_crop_r = individual_croppings[0]
         for crop_u, crop_d, crop_l, crop_r in individual_croppings[1:]:
             min_crop_u = min(min_crop_u, crop_u)
@@ -147,7 +146,7 @@ def entry_point(parser, args):
         paddings = [(padding, padding, padding, padding)] * len(src_ims)
     else:
         # Compute cropping boarders.
-        croppings = [ct.image.compute_cropping(src_im) for src_im in src_ims]
+        croppings = ct.utility.mt_loop(ct.image.compute_cropping, src_ims)
 
         # Compute paddings.
         if args.pad_pixel != 0:

--- a/camtools/tools/crop_boarders.py
+++ b/camtools/tools/crop_boarders.py
@@ -8,11 +8,13 @@ ct crop-boarders *.png --pad_pixel 10 --skip_cropped --same_crop
 ```
 """
 
-from pathlib import Path
 import argparse
+from pathlib import Path
+
 import numpy as np
-import camtools as ct
 from tqdm import tqdm
+
+import camtools as ct
 
 
 def instantiate_parser(parser):
@@ -106,10 +108,8 @@ def entry_point(parser, args):
         ]
 
     # Read.
-    src_ims = [
-        ct.io.imread(src_path, alpha_mode="white")
-        for src_path in tqdm(src_paths, desc="Reading images")
-    ]
+    src_ims = ct.utility.mt_loop(ct.io.imread, src_paths, alpha_mode="white")
+
     for src_im in src_ims:
         if not src_im.dtype == np.float32:
             raise ValueError(f"Input image {src_path} must be of dtype float32.")


### PR DESCRIPTION
## Summary

This PR focuses on optimizing performance for cropping and reading operations by leveraging parallel processing. The addition of `mt_loop` and `mp_loop` functions introduces flexible utilities for applying any operation in parallel, offering significant speed improvements for processing large sets of images or data.

## Changes

1. **Performance Enhancements for Image Cropping:**
   Improved the image cropping performance by introducing a new version of the `ct.image.compute_cropping` function for enhanced efficiency.

    ```python
    import camtools as ct
    image = ct.io.imread("example.png")
    cropping = ct.image.compute_cropping(image)
    ```

2. **Parallel Image Reading and Cropping:**
   Integrated parallel processing for reading and cropping images, utilizing the newly added `mt_loop` and `mp_loop` functions in `camtools/utility.py`. These functions enable multi-threaded and multi-process execution, respectively, significantly speeding up the operations when working with multiple images.

    ```bash
    # This will be automatically parallelized
    ct crop-boarders --same_crop *.png
    ```

3. **Utility Functions for Parallel Loops:**
   Added `mt_loop` for multi-threading and `mp_loop` for multi-processing in `camtools/utility.py`, facilitating parallel execution of functions over iterables. These utility functions aim to generalize parallel execution patterns, making it easy to apply any function in a multi-threaded or multi-processed manner across a list of inputs.

    - **Multi-threading Example:**
      ```python
      import camtools as ct
      inputs = range(10)
      results = ct.utility.mt_loop(my_function, inputs)
      ```

    - **Multi-processing Example:**
      ```python
      import camtools as ct
      inputs = range(10)
      results = ct.utility.mp_loop(my_function, inputs)
      ```