### PR TITLE
build: use importlib.metadata to get version for py>=3.8

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.7", "3.8"]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.7", "3.8"]
 
     steps:
       - uses: actions/checkout@v3

--- a/camtools/__init__.py
+++ b/camtools/__init__.py
@@ -16,6 +16,14 @@ from . import solver
 from . import transform
 from . import util
 
-import pkg_resources
 
-__version__ = pkg_resources.get_distribution("camtools").version
+try:
+    # Python >= 3.8
+    from importlib.metadata import version
+
+    __version__ = version("camtools")
+except ImportError:
+    # Python < 3.8
+    import pkg_resources
+
+    __version__ = pkg_resources.get_distribution("camtools").version


### PR DESCRIPTION
Fixes deprecated warning. 