### PR TITLE
refactor: improved projection APIs

### DIFF
--- a/camtools/convert.py
+++ b/camtools/convert.py
@@ -3,6 +3,7 @@ import numpy as np
 import torch
 
 from . import sanity
+from . import convert
 
 
 def pad_0001(array):
@@ -423,17 +424,14 @@ def K_T_to_W2P(K, T):
 
 def P_to_W2P(P):
     sanity.assert_shape_3x4(P, name="P")
-    if torch.is_tensor(P):
-        bottom_row = torch.tensor([0, 0, 0, 1], device=P.device, dtype=P.dtype)
-        W2P = torch.vstack((P, bottom_row))
-    else:
-        bottom_row = np.array([[0, 0, 0, 1]])
-        W2P = np.vstack((P, bottom_row))
+    W2P = convert.pad_0001(P)
     return W2P
 
 
 def W2P_to_P(W2P):
-    P = W2P[:3, :4]
+    if W2P.shape != (4, 4):
+        raise ValueError(f"Expected W2P of shape (4, 4), but got {W2P.shape}.")
+    P = convert.rm_pad_0001(W2P, check_vals=True)
     return P
 
 

--- a/camtools/convert.py
+++ b/camtools/convert.py
@@ -52,7 +52,7 @@ def pad_0001(array):
 
 def rm_pad_0001(array, check_vals=False):
     """
-    Remove the homogeneous bottom row [0, 0, 0, 1].
+    Remove the bottom row of [0, 0, 0, 1].
 
     Args:
         array: (4, 4) or (N, 4, 4).
@@ -115,6 +115,44 @@ def rm_pad_0001(array, check_vals=False):
                 raise ValueError("Should not reach here.")
 
     return array[..., :3, :]
+
+
+def to_homo(array):
+    """
+    Convert a 2D array to homogeneous coordinates by appending a column of ones.
+
+    Args:
+        array: A 2D numpy array of shape (N, M).
+
+    Returns:
+        A numpy array of shape (N, M+1) with a column of ones appended.
+    """
+    if not isinstance(array, np.ndarray) or array.ndim != 2:
+        raise ValueError("Input must be a 2D numpy array")
+
+    ones = np.ones((array.shape[0], 1), dtype=array.dtype)
+    return np.hstack((array, ones))
+
+
+def from_homo(array):
+    """
+    Convert an array from homogeneous to Cartesian coordinates by dividing by the
+    last column and removing it.
+
+    Args:
+        array: A 2D numpy array of shape (N, M) in homogeneous coordinates.
+
+    Returns:
+        A numpy array of shape (N, M-1) in Cartesian coordinates.
+    """
+    if not isinstance(array, np.ndarray) or array.ndim != 2:
+        raise ValueError("Input must be a 2D numpy array")
+    if array.shape[1] < 2:
+        raise ValueError(
+            "Input array must have at least two columns for removing homogeneous coordinate"
+        )
+
+    return array[:, :-1] / array[:, -1, np.newaxis]
 
 
 def R_to_quat(R):

--- a/camtools/convert.py
+++ b/camtools/convert.py
@@ -129,7 +129,7 @@ def to_homo(array):
         A numpy array of shape (N, M+1) with a column of ones appended.
     """
     if not isinstance(array, np.ndarray) or array.ndim != 2:
-        raise ValueError("Input must be a 2D numpy array")
+        raise ValueError(f"Input must be a 2D numpy array, but got {array.shape}.")
 
     ones = np.ones((array.shape[0], 1), dtype=array.dtype)
     return np.hstack((array, ones))
@@ -147,10 +147,11 @@ def from_homo(array):
         A numpy array of shape (N, M-1) in Cartesian coordinates.
     """
     if not isinstance(array, np.ndarray) or array.ndim != 2:
-        raise ValueError("Input must be a 2D numpy array")
+        raise ValueError(f"Input must be a 2D numpy array, but got {array.shape}.")
     if array.shape[1] < 2:
         raise ValueError(
-            "Input array must have at least two columns for removing homogeneous coordinate"
+            f"Input array must have at least two columns for removing "
+            f"homogeneous coordinate, but got shape {array.shape}."
         )
 
     return array[:, :-1] / array[:, -1, np.newaxis]

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -1,5 +1,6 @@
 import numpy as np
 import camtools as ct
+import pytest
 
 np.set_printoptions(formatter={"float": "{: 0.2f}".format})
 
@@ -234,3 +235,53 @@ def test_convert_T_opencv_to_opengl():
             rtol=1e-5,
             atol=1e-5,
         )
+
+
+def test_to_homo():
+    # Regular case
+    src = np.array(
+        [
+            [1, 2],
+            [3, 4],
+        ]
+    )
+    dst_gt = np.array(
+        [
+            [1, 2, 1],
+            [3, 4, 1],
+        ]
+    )
+    dst = ct.convert.to_homo(src)
+    np.testing.assert_array_equal(dst, dst_gt)
+
+    # Exception case
+    with pytest.raises(ValueError) as _:
+        src = np.array([1, 2, 3])
+        ct.convert.to_homo(src)
+
+
+def test_from_homo():
+    src = np.array(
+        [
+            [2, 4, 2],
+            [6, 8, 1],
+        ]
+    )
+    dst_gt = np.array(
+        [
+            [1, 2],
+            [6, 8],
+        ]
+    )
+    dst = ct.convert.from_homo(src)
+    np.testing.assert_array_equal(dst, dst_gt)
+
+    # Exception case for non-2D input
+    with pytest.raises(ValueError) as _:
+        src = np.array([1, 2, 3])
+        ct.convert.from_homo(src)
+
+    # Exception case for insufficient columns
+    with pytest.raises(ValueError) as _:
+        src = np.array([[1]])
+        ct.convert.from_homo(src)


### PR DESCRIPTION
### New Functions
- `ct.project.depth_to_point_cloud()`: Unifies and replaces the functionality of the removed functions, enabling conversion of depth images to point clouds with 
    - optional color information, and
    - option to choose dense image form or point cloud form.
- `ct.convert.to_homo()`: Appends a column of ones to a 2D array, converting it to homogeneous coordinates.
- `ct.convert.from_homo()`: Converts from homogeneous to Cartesian coordinates by dividing by the last column.

### Removed Functions
- `ct.project.im_depth_to_points()`: This is replaced by `ct.project.depth_to_point_cloud()`.
- `ct.project.im_depth_to_im_points()`: This is replaced by `ct.project.depth_to_point_cloud()`.
- `ct.project.im_depth_im_color_to_points_colors()`: This is replaced by `ct.project.depth_to_point_cloud()`.