### PR TITLE
feat: flexible numpy/torch backend and tensor type checking

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -25,6 +25,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[dev]
-      - name: Run unit tests
+      - name: Run unit tests (numpy)
+        run: |
+          pytest
+      - name: Install dependencies with torch
+        run: |
+          pip install -e .[torch]
+      - name: Run unit tests (numpy + torch)
         run: |
           pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 camtools/assets/bbox_box.png
 camtools/assets/bbox_box_blender.png
 
+# cProfile
+*.prof
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/camtools/__init__.py
+++ b/camtools/__init__.py
@@ -1,4 +1,5 @@
 from . import artifact
+from . import backend
 from . import camera
 from . import colmap
 from . import colormap
@@ -15,7 +16,6 @@ from . import sanity
 from . import solver
 from . import transform
 from . import util
-
 
 try:
     # Python >= 3.8

--- a/camtools/backend.py
+++ b/camtools/backend.py
@@ -1,0 +1,506 @@
+import collections.abc
+import inspect
+import typing
+import warnings
+from functools import lru_cache, wraps
+from inspect import signature
+from typing import Any, Literal, Tuple, Union, Dict, List
+
+import jaxtyping
+import numpy as np
+
+_default_backend = "numpy"
+
+
+@lru_cache(maxsize=None)
+def _safely_import_torch():
+    """
+    Open3D has an issue where it must be imported before torch. If Open3D is
+    installed, this function will import Open3D before torch. Otherwise, it
+    will return simply import and return torch.
+
+    Use this function to import torch within camtools to handle the Open3D
+    import order issue. That is, within camtools, we shall avoid `import torch`,
+    and instead use `from camtools.backend import torch`. As torch is an
+    optional dependency for camtools, this function will return None if torch
+    is not available.
+
+    Returns:
+        module: The torch module if available, otherwise None.
+    """
+    try:
+        __import__("open3d")
+    except ImportError:
+        pass
+
+    try:
+        _torch = __import__("torch")
+        return _torch
+    except ImportError:
+        return None
+
+
+torch = _safely_import_torch()
+
+
+@lru_cache(maxsize=None)
+def is_torch_available():
+    return _safely_import_torch() is not None
+
+
+@lru_cache(maxsize=None)
+def _safely_import_ivy():
+    """
+    This function sets up the warnings filter to suppress the deprecation
+    before importing ivy. This is a temporary workaround to suppress the
+    deprecation warning from numpy 2.0.
+
+    Within camtools, we shall avoid `import ivy`, and instead use
+    `from camtools.backend import ivy`.
+    """
+    warnings.filterwarnings(
+        "ignore",
+        category=DeprecationWarning,
+        message=".*numpy.core.numeric is deprecated.*",
+    )
+    return __import__("ivy")
+
+
+ivy = _safely_import_ivy()
+
+
+class Tensor:
+    """
+    An abstract tensor type for type hinting only.
+    Typically np.ndarray or torch.Tensor is supported.
+    """
+
+    pass
+
+
+def set_backend(backend: Literal["numpy", "torch"]) -> None:
+    """
+    Set the default backend for camtools.
+    """
+    global _default_backend
+    _default_backend = backend
+
+
+def get_backend() -> str:
+    """
+    Get the default backend for camtools.
+    """
+    return _default_backend
+
+
+class ScopedBackend:
+    """
+    Context manager to temporarily set the backend for camtools.
+
+    Example:
+    ```python
+    with ct.backend.ScopedBackend("torch"):
+        # Code that uses torch backend here
+        pass
+
+    # Code that uses the default backend here
+    ```
+    """
+
+    def __init__(self, target_backend: Literal["numpy", "torch"]):
+        self.target_backend = target_backend
+
+    def __enter__(self):
+        self.stashed_backend = get_backend()
+        set_backend(self.target_backend)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        set_backend(self.stashed_backend)
+
+
+def tensor_auto_backend(func, force_backend=None):
+    """
+    Automatic backend selection based on the backend of type-annotated input
+    tensors. If there are no tensors, or if the tensors do not have the
+    necessary type annotations, the default backend is used. The function
+    targets specifically jaxtyping.AbstractArray annotations to determine tensor
+    treatment and backend usage.
+
+    Detailed behaviors:
+    1. Only processes input arguments that are explicitly typed as
+       jaxtyping.AbstractArray. Arguments without this type hint or with
+       different annotations maintain their default behavior without backend
+       modification.
+    2. Supports handling of numpy.ndarray, torch.Tensor, and Python lists that
+       should be converted to tensors based on their type hints.
+    3. If the type hint is jaxtyping.AbstractArray and the argument is a list,
+       the list will be converted to a tensor using the native array
+       functionality of the active backend.
+    4. Ensures all tensor arguments must be from the same backend to avoid
+       conflicts.
+    5. Uses the default backend if no tensors are present or if the tensors do
+       not require specific backend handling based on their annotations.
+    6. If force_backend is specified, the inferred backend from arguments
+       and type hints will be ignored, and the specified backend will be used
+       instead. Don't confuse this with the default backend as this takes
+       higher precedence.
+    """
+
+    def _collect_tensors(args: List[Any]) -> List[Any]:
+        """
+        Recursively collects np.ndarray and torch.Tensor objects. Other types
+        including lists are ignored. Processing lists can be slow, as we need
+        to check each element for tensors.
+        """
+        if is_torch_available():
+            tensor_types = (np.ndarray, torch.Tensor)
+        else:
+            tensor_types = (np.ndarray,)
+
+        tensors = []
+        for arg in args:
+            if isinstance(arg, tensor_types):
+                tensors.append(arg)
+
+        return tensors
+
+    def _determine_backend(
+        arg_name_to_arg: Dict[str, Any],
+        arg_name_to_hint: Dict[str, Any],
+    ) -> str:
+        """
+        Also throws an error if the tensors are not from the same backend.
+        """
+        tensor_annotated_args = []
+        for arg_name, hint in arg_name_to_hint.items():
+            if (
+                arg_name in arg_name_to_arg
+                and inspect.isclass(hint)
+                and issubclass(hint, jaxtyping.AbstractArray)
+            ):
+                arg = arg_name_to_arg[arg_name]
+                tensor_annotated_args.append(arg)
+
+        tensors = _collect_tensors(tensor_annotated_args)
+
+        if not tensors:
+            return get_backend()
+        elif all(isinstance(t, np.ndarray) for t in tensors):
+            return "numpy"
+        elif is_torch_available() and all(isinstance(t, torch.Tensor) for t in tensors):
+            return "torch"
+        else:
+            raise TypeError("All tensors must be from the same backend.")
+
+    def _convert_tensor_to_backend(arg, backend):
+        """
+        Convert the tensor to the specified backend. It shall already be checked
+        that the arg is a tensor-like object, the tensor is type-annotated, and
+        the backend is valid.
+        """
+        if backend == "numpy":
+            if isinstance(arg, np.ndarray):
+                return arg
+            elif is_torch_available() and isinstance(arg, torch.Tensor):
+                return arg.detach().cpu().numpy()
+            elif isinstance(arg, list):
+                return np.array(arg)  # Handle dtypes?
+            else:
+                raise ValueError(
+                    f"Unsupported type {type(arg)} for conversion to numpy."
+                )
+        elif backend == "torch":
+            if not is_torch_available:
+                raise ValueError("Torch is not available.")
+            elif isinstance(arg, torch.Tensor):
+                return arg
+            elif isinstance(arg, np.ndarray):
+                return torch.from_numpy(arg)
+            elif isinstance(arg, list):
+                return torch.tensor(arg)
+            else:
+                raise ValueError(
+                    f"Unsupported type {type(arg)} for conversion to torch."
+                )
+        else:
+            raise ValueError(f"Unsupported backend {backend}.")
+
+    def _convert_bound_args_to_backend(
+        bound_args: inspect.BoundArguments,
+        arg_name_to_hint: Dict[str, Any],
+        backend: str,
+    ):
+        """
+        Update the bound_args inplace to convert tensors to the specified backend.
+        The bound_args is also returned for convenience.
+        """
+        for arg_name, arg in bound_args.arguments.items():
+            if (
+                arg_name in arg_name_to_hint
+                and inspect.isclass(arg_name_to_hint[arg_name])
+                and issubclass(arg_name_to_hint[arg_name], jaxtyping.AbstractArray)
+            ):
+                bound_args.arguments[arg_name] = _convert_tensor_to_backend(
+                    arg, backend
+                )
+        return bound_args
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        # Unpack args and hints
+        sig = signature(func)
+        bound_args = sig.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+        arg_name_to_arg = bound_args.arguments
+        arg_name_to_hint = typing.get_type_hints(func)
+
+        # Determine backend
+        if force_backend is None:
+            arg_backend = _determine_backend(arg_name_to_arg, arg_name_to_hint)
+        elif force_backend in ("numpy", "torch"):
+            arg_backend = force_backend
+        else:
+            raise ValueError(f"Unsupported forced backend {force_backend}.")
+
+        stashed_backend = ivy.current_backend()
+        ivy.set_backend(arg_backend)
+
+        # Convert tensors to the backend
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            with ivy.ArrayMode(False):
+                # Convert list/tensor -> native tensor
+                bound_args = _convert_bound_args_to_backend(
+                    bound_args,
+                    arg_name_to_hint,
+                    arg_backend,
+                )
+                # Call the function
+                result = func(*bound_args.args, **bound_args.kwargs)
+
+        # Reset backend
+        ivy.set_backend(stashed_backend)
+        return result
+
+    return wrapper
+
+
+def tensor_numpy_backend(func):
+    """
+    Run this function by first converting its input tensors to numpy arrays.
+    Only jaxtyping-annotated tensors will be processed. This wrapper shall be
+    used if the internal implementation is numpy-only or if we expect to return
+    numpy arrays.
+
+    Behavior:
+    1. Only converts arguments that are annotated explicitly with a jaxtyping
+       tensor type. If the type hint is a container of tensors, the conversion
+       will not be performed.
+    2. Supports conversion of lists into numpy arrays if they are intended to be
+       tensors, according to the function's type annotations.
+    3. The conversion is applied to top-level arguments and does not recursively
+       convert tensors within nested custom types (e.g., custom classes
+       containing tensors).
+    4. This decorator is particularly useful for functions requiring consistent
+       tensor handling specifically with numpy, ensuring compatibility and
+       simplifying operations that depend on numpy's functionality.
+
+    Note:
+    - The decorator inspects type annotations and applies conversions where
+      specified.
+    - Lists of tensors or tensors within lists annotated as tensors
+      will be converted to numpy arrays if not already in that format.
+
+    This function simply wraps the tensor_auto_backend function with the
+    force_backend argument set to "numpy".
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        # Wrap the original function with tensor_auto_backend enforcing numpy.
+        return tensor_auto_backend(func, force_backend="numpy")(*args, **kwargs)
+
+    return wrapper
+
+
+def tensor_torch_backend(func):
+    """
+    Run this function by first converting its input tensors to torch tensors.
+    Only jaxtyping-annotated tensors will be processed. This wrapper shall be
+    used if the internal implementation is torch-only or if we expect to return
+    torch tensors.
+
+    Behavior:
+    1. Only converts arguments that are annotated explicitly with a jaxtyping
+       tensor type. If the type hint is a container of tensors, the conversion
+       will not be performed.
+    2. Supports conversion of lists into torch tensors if they are intended to be
+       tensors, according to the function's type annotations.
+    3. The conversion is applied to top-level arguments and does not recursively
+       convert tensors within nested custom types (e.g., custom classes
+       containing tensors).
+    4. This decorator is particularly useful for functions requiring consistent
+       tensor handling specifically with torch, ensuring compatibility and
+       simplifying operations that depend on torch's functionality.
+
+    Note:
+    - The decorator inspects type annotations and applies conversions where
+      specified.
+    - Lists of tensors or tensors within lists annotated as tensors
+      will be converted to torch tensors if not already in that format.
+
+    This function simply wraps the tensor_auto_backend function with the
+    force_backend argument set to "torch".
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        # Wrap the original function with tensor_auto_backend enforcing torch.
+        return tensor_auto_backend(func, force_backend="torch")(*args, **kwargs)
+
+    return wrapper
+
+
+def tensor_type_check(func):
+    """
+    A decorator to enforce type and shape specifications as per type hints.
+
+    The checks will only be performed if the tensor's type hint is exactly
+    jaxtyping.AbstractArray. If it is a container of tensors, the check will
+    not be performed. For example, Float[Tensor, "..."] will be checked, while
+    List[Float[Tensor, "..."]] will not be checked.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        sig = signature(func)
+        bound_args = sig.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+        arg_name_to_arg = bound_args.arguments
+        arg_name_to_hint = typing.get_type_hints(func)
+
+        for arg_name, arg in arg_name_to_arg.items():
+            if arg_name in arg_name_to_hint:
+                hint = arg_name_to_hint[arg_name]
+                if inspect.isclass(hint) and issubclass(hint, jaxtyping.AbstractArray):
+                    _assert_tensor_hint(hint, arg, arg_name)
+
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def _dtype_to_str(dtype):
+    """
+    Convert numpy or torch dtype to string
+
+    - "bool"
+    - "bool_"
+    - "uint4"
+    - "uint8"
+    - "uint16"
+    - "uint32"
+    - "uint64"
+    - "int4"
+    - "int8"
+    - "int16"
+    - "int32"
+    - "int64"
+    - "bfloat16"
+    - "float16"
+    - "float32"
+    - "float64"
+    - "complex64"
+    - "complex128"
+    """
+    if isinstance(dtype, np.dtype):
+        return dtype.name
+
+    if is_torch_available():
+        if isinstance(dtype, torch.dtype):
+            return str(dtype).split(".")[1]
+
+    return ValueError(f"Unknown dtype {dtype}.")
+
+
+def _shape_from_dim_str(dim_str: str) -> Tuple[Union[int, None, str], ...]:
+    shape = []
+    elements = dim_str.split()
+    for elem in elements:
+        if elem == "...":
+            shape.append("...")
+        elif elem.isdigit():
+            shape.append(int(elem))
+        else:
+            shape.append(None)
+    return tuple(shape)
+
+
+def _is_shape_compatible(
+    arg_shape: Tuple[Union[int, None, str], ...],
+    gt_shape: Tuple[Union[int, None, str], ...],
+) -> bool:
+    if "..." in gt_shape:
+        if len(arg_shape) < len(gt_shape) - 1:
+            return False
+        # We only support one ellipsis for now
+        if gt_shape.count("...") > 1:
+            raise ValueError(
+                "Only one ellipsis is supported in the shape hint for now."
+            )
+
+        # Compare dimensions before and after the ellipsis
+        pre_ellipsis = gt_shape.index("...")
+        post_ellipsis = len(gt_shape) - pre_ellipsis - 1
+        return all(
+            arg_shape[i] == gt_shape[i] or gt_shape[i] is None
+            for i in range(pre_ellipsis)
+        ) and all(
+            arg_shape[-i - 1] == gt_shape[-i - 1] or gt_shape[-i - 1] is None
+            for i in range(post_ellipsis)
+        )
+    else:
+        if len(arg_shape) != len(gt_shape):
+            return False
+        return all(
+            arg_dim == gt_dim or gt_dim is None
+            for arg_dim, gt_dim in zip(arg_shape, gt_shape)
+        )
+
+
+def _assert_tensor_hint(
+    hint: jaxtyping.AbstractArray,
+    arg: Any,
+    arg_name: str,
+):
+    """
+    Args:
+        hint: A type hint for a tensor, must be javtyping.AbstractArray.
+        arg: An argument to check, typically a tensor.
+        arg_name: The name of the argument, for error messages.
+    """
+    # Check array types.
+    if is_torch_available():
+        valid_array_types = (np.ndarray, torch.Tensor)
+    else:
+        valid_array_types = (np.ndarray,)
+    if not isinstance(arg, valid_array_types):
+        raise TypeError(
+            f"{arg_name} must be of type {valid_array_types}, "
+            f"but got type {type(arg)}."
+        )
+
+    # Check shapes.
+    gt_shape = _shape_from_dim_str(hint.dim_str)
+    if not _is_shape_compatible(arg.shape, gt_shape):
+        raise TypeError(
+            f"{arg_name} must be of shape {gt_shape}, but got shape {arg.shape}."
+        )
+
+    # Check dtype.
+    gt_dtypes = hint.dtypes
+    if _dtype_to_str(arg.dtype) not in gt_dtypes:
+        raise TypeError(
+            f"{arg_name} must be of dtype {gt_dtypes}, "
+            f"but got dtype {_dtype_to_str(arg.dtype)}."
+        )

--- a/camtools/metric.py
+++ b/camtools/metric.py
@@ -9,6 +9,7 @@ from typing import Tuple
 from . import image
 from . import io
 from . import sanity
+from .backend import torch
 
 
 def image_psnr(
@@ -94,7 +95,6 @@ def image_lpips(
     Returns:
         LPIPS value in float.
     """
-    import torch
     import lpips
 
     if im_mask is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ Homepage = "https://github.com/yxlao/camtools"
 dev = [
   "black>=22.1.0",
   "pytest>=6.2.2",
+  "pytest-benchmark>=4.0.0",
   "ipdb",
 ]
 torch = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
   "matplotlib>=3.3.4",
   "scikit-image>=0.16.2",
   "tqdm>=4.60.0",
+  "ivy>=0.0.8.0",
+  "jaxtyping>=0.2.12",
 ]
 description = "CamTools: Camera Tools for Computer Vision."
 license = {text = "MIT"}

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
 from setuptools import setup
 
-
 setup()


### PR DESCRIPTION
## TL;DR
<h3 align="center">Flexible Backend + Type Checking</h3>
We want CamTools to seamlessly work with NumPy/Torch, and enforce dtype and shape checking for tensors. We want all these to work automagically with the help of decorators. This PR provides the initial infrastructure to do that while future PRs will incrementally migrate the existing functions.

```python
@ct.backend.tensor_backend_auto
def func(t: Float[Tensor, "n 3"]):
    """
    Automatically use backend determined by `t`. 
    Also check type and shape of `t`.
    """
    pass

@ct.backend.tensor_backend_numpy
def func(t: Float[Tensor, "n 3"]):
    """
    Attempts to convert `t` to NumPy. 
    Also check type and shape of `t`.
    """
    pass
```

## Overall goals

1. All functions in CamTools shall be able to handle both NumPy arrays and Torch tensors. This shall be achieved automatically by decorators.
2. CamTools determines the backend to use by looking at the input arguments. Otherwise, the default backend is NumPy.
3. Torch shall not be a compulsory dependency of CamTools, yet CamTools can detect if Torch is installed and enable the corresponding features.
4. Functions in CamTools shall be type-hinted with the expected tensor shape and dtype. The shape and dtypes are automatically checked and enforced by decorators. Compatible list inputs are automatically converted to the native tensor format if the type hint is a tensor.

## Key usages

With this PR, the key functions include:

1. Tensor-like inputs shall be type-annotated with `jaxtyping`, specifying the shape and dtype. A single tensor type or a union of tensor types can be used. Flexible shape (e.g. "... 3") or context-dependent shape (e.g. "n 3") can be specified.
2. `@ct.backend.tensor_backend_auto`: Automatically determines the backend from the input arguments. Compatible list inputs are automatically converted to the native tensor format. This will only handle arguments that are hinted as tensors.
3. `@ct.backend.tensor_backend_numpy` and `@ct.backend.tensor_backend_torch`: Enforces the use of NumPy and Torch backends by converting input tensors to NumPy or Torch, respectively. Compatible list inputs are automatically converted to the native tensor format. This will only handle arguments that are hinted as tensors.
4. `ct.backend.enable_tensor_check()` and `ct.backend.disable_tensor_check()`: Enable or disable tensor type checking (for dtype and shape) globally. By default, the tensor type checking is enabled. The checks will be done if `@ct.backend.tensor_backend_xxx` decorators are used and the argument is hinted as a tensor.
5. Inside the functions, you may use `ivy` to for computation or use native Python operators. The goal is to make the functions compatible with both NumPy and Torch.

Here are some examples.

```python
import camtools as ct
from camtools.backend import Tensor, ivy
from jaxtyping import Float

@ct.backend.tensor_backend_auto
def add(x: Float[Tensor, "2 3"], y: Float[Tensor, "1 3"]) -> Float[Tensor, "2 3"]:
     # Or, you may use ivy:
     # return ivy.add(x, y)
     return x + y

# Numpy inputs: works, returns numpy array
x = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
y = np.array([[1.0, 1.0, 1.0]])
result = add(x, y)

# Torch inputs: works, returns torch tensor
x = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
y = torch.tensor([[1.0, 1.0, 1.0]])
result = add(x, y)

# Mixed numpy and list: works, returns numpy array
x = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
y = [[1.0, 1.0, 1.0]]
result = add(x, y)

# Mixed torch and list: works, returns torch tensor
x = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
y = [[1.0, 1.0, 1.0]]
result = add(x, y)

# Mixed numpy and torch: exception
x = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
y = torch.tensor([[1.0, 1.0, 1.0]])
result = add(x, y)  # ValueError: Tensors must be from the same backend

# Numpy inputs with wrong shape: exception
x = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
y = np.array([[1.0, 1.0, 1.0], [2.0, 2.0, 2.0]])
result = add(x, y)  # ValueError: Expected shape (1, 3), but got (2, 3)

# Numpy inputs with wrong dtype: exception
x = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
y = np.array([[1, 1, 1]]) # int dtype
result = add(x, y)  # ValueError: Expected dtype float32, but got int64

@ct.backend.tensor_backend_numpy
def add_numpy(x: Float[Tensor, "2 3"], y: Float[Tensor, "1 3"]) -> Float[Tensor, "2 3"]:
    return x + y

# Mixed numpy and torch: works, returns numpy array
x = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
y = torch.tensor([[1.0, 1.0, 1.0]])
result = add_numpy(x, y)

@ct.backend.tensor_backend_torch
def add_torch(x: Float[Tensor, "2 3"], y: Float[Tensor, "1 3"]) -> Float[Tensor, "2 3"]:
    return x + y

# Mixed numpy and torch: works, returns torch tensor
x = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
y = torch.tensor([[1.0, 1.0, 1.0]])
result = add_torch(x, y)
```

## Other notes

- Tensor creation APIs are supported for tensor creation using different backends: `ct.backend.create_array`, `ct.backend.create_ones`, `ct.backend.create_zeros`, and `ct.backend.create_empty`.
- Union of hints is supported. For example, `Union[Float[Tensor, "3 4"], Float[Tensor, "N 3 4"]]`.
- You shall import `ivy` and `torch` from `camtools.backend`, as this sets up some internal configurations for the backend.
- The wrappers are carefully optimized to minimize the overhead of backend conversion and type checking. More details in https://github.com/yxlao/camtools/pull/66.
