### PR TITLE
feat: standardized depth image and distance image projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ clear and easy-to-use APIs.
    # Back-project depth image to 3D points.
    points = ct.project.im_depth_to_points(im_depth, K, T)
 
-   # Ray cast a triangle mesh to depth image.
-   im_depth = ct.raycast.mesh_to_distances(mesh, Ks, Ts, height, width)
+   # Ray cast a triangle mesh to depth image given the camera parameters.
+   im_depth = ct.raycast.mesh_to_im_depth(mesh, K, T, height, width)
 
    # And more...
    ```

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ clear and easy-to-use APIs.
    points = ct.project.im_depth_to_points(im_depth, K, T)
 
    # Ray cast a triangle mesh to depth image.
-   im_depth = ct.raycast.mesh_to_depths(mesh, Ks, Ts, height, width)
+   im_depth = ct.raycast.mesh_to_distances(mesh, Ks, Ts, height, width)
 
    # And more...
    ```

--- a/camtools/colormap.py
+++ b/camtools/colormap.py
@@ -50,23 +50,3 @@ def normalize(array, vmin=0.0, vmax=1.0, clip=False):
         array = (array - amin) / (amax - amin) * (vmax - vmin) + vmin
 
     return array
-
-
-def main():
-    """
-    Test create color map image.
-    """
-    height = 200
-    width = 1600
-
-    colors = query(np.linspace(0, 1, num=width))
-    im = np.zeros((height, width, 3), dtype=np.float32)
-    for i in range(width):
-        im[:, i : i + 1, :] = colors[i]
-
-    im_path = "colormap.png"
-    io.imwrite(im_path, im)
-
-
-if __name__ == "__main__":
-    main()

--- a/camtools/convert.py
+++ b/camtools/convert.py
@@ -578,3 +578,40 @@ def im_distance_to_im_depth(
     im_depth = im_depth.astype(dtype)
 
     return im_depth
+
+
+def im_depth_to_im_distance(
+    im_depth: Float[np.ndarray, "h w"],
+    K: Float[np.ndarray, "3 3"],
+) -> Float[np.ndarray, "h w"]:
+    """
+    Convert depth image to distance image.
+
+    Args:
+        im_depth: Depth image (H, W), float.
+        K: Camera intrinsic matrix (3, 3).
+
+    Returns:
+        Distance image (H, W), float.
+    """
+    if not im_depth.ndim == 2:
+        raise ValueError(
+            f"Expected im_depth of shape (H, W), but got {im_depth.shape}."
+        )
+    sanity.assert_K(K)
+    height, width = im_depth.shape
+    fx, fy = K[0, 0], K[1, 1]
+    cx, cy = K[0, 2], K[1, 2]
+    dtype = im_depth.dtype
+
+    u = np.arange(width)
+    v = np.arange(height)
+    u_grid, v_grid = np.meshgrid(u, v)
+
+    u_norm = (u_grid - cx) / fx
+    v_norm = (v_grid - cy) / fy
+    norm_square = u_norm**2 + v_norm**2
+    im_distance = im_depth * np.sqrt(norm_square + 1)
+    im_distance = im_distance.astype(dtype)
+
+    return im_distance

--- a/camtools/convert.py
+++ b/camtools/convert.py
@@ -1,6 +1,8 @@
 import cv2
 import numpy as np
 import open3d as o3d
+from jaxtyping import Float
+from typing import Optional
 
 from . import sanity
 from . import convert
@@ -508,7 +510,10 @@ def spherical_to_T_towards_origin(radius, theta, phi):
     return T
 
 
-def mesh_to_lineset(mesh: o3d.geometry.TriangleMesh) -> o3d.geometry.LineSet:
+def mesh_to_lineset(
+    mesh: o3d.geometry.TriangleMesh,
+    color: Optional[Float[np.ndarray, "3"]] = None,
+) -> o3d.geometry.LineSet:
     """
     Convert Open3D mesh to Open3D lineset.
     """
@@ -529,5 +534,10 @@ def mesh_to_lineset(mesh: o3d.geometry.TriangleMesh) -> o3d.geometry.LineSet:
     lineset = o3d.geometry.LineSet()
     lineset.points = o3d.utility.Vector3dVector(vertices)
     lineset.lines = o3d.utility.Vector2iVector(edges)
+
+    if color is not None:
+        if len(color) != 3:
+            raise ValueError(f"Expected color of shape (3,), but got {color.shape}.")
+        lineset.paint_uniform_color(color)
 
     return lineset

--- a/camtools/convert.py
+++ b/camtools/convert.py
@@ -1,5 +1,6 @@
 import cv2
 import numpy as np
+import open3d as o3d
 
 from . import sanity
 from . import convert
@@ -505,3 +506,28 @@ def spherical_to_T_towards_origin(radius, theta, phi):
     T = pose_to_T(pose)
 
     return T
+
+
+def mesh_to_lineset(mesh: o3d.geometry.TriangleMesh) -> o3d.geometry.LineSet:
+    """
+    Convert Open3D mesh to Open3D lineset.
+    """
+    if not isinstance(mesh, o3d.geometry.TriangleMesh):
+        raise ValueError(f"Expected Open3D mesh, but got {type(mesh)}.")
+
+    vertices = np.asarray(mesh.vertices)
+    triangles = np.asarray(mesh.triangles)
+
+    edges = set()
+    for triangle in triangles:
+        edges.add(tuple(sorted([triangle[0], triangle[1]])))
+        edges.add(tuple(sorted([triangle[1], triangle[2]])))
+        edges.add(tuple(sorted([triangle[2], triangle[0]])))
+
+    edges = np.array(list(edges))
+
+    lineset = o3d.geometry.LineSet()
+    lineset.points = o3d.utility.Vector3dVector(vertices)
+    lineset.lines = o3d.utility.Vector2iVector(edges)
+
+    return lineset

--- a/camtools/convert.py
+++ b/camtools/convert.py
@@ -541,3 +541,40 @@ def mesh_to_lineset(
         lineset.paint_uniform_color(color)
 
     return lineset
+
+
+def im_distance_to_im_depth(
+    im_distance: Float[np.ndarray, "H W"],
+    K: Float[np.ndarray, "3 3"],
+) -> Float[np.ndarray, "H W"]:
+    """
+    Convert distance image to depth image.
+
+    Args:
+        im_distance: Distance image (H, W), float.
+        K: Camera intrinsic matrix (3, 3).
+
+    Returns:
+        Depth image (H, W), float.
+    """
+    if not im_distance.ndim == 2:
+        raise ValueError(
+            f"Expected im_distance of shape (H, W), but got {im_distance.shape}."
+        )
+    sanity.assert_K(K)
+    height, width = im_distance.shape
+    fx, fy = K[0, 0], K[1, 1]
+    cx, cy = K[0, 2], K[1, 2]
+    dtype = im_distance.dtype
+
+    u = np.arange(width)
+    v = np.arange(height)
+    u_grid, v_grid = np.meshgrid(u, v)
+
+    u_norm = (u_grid - cx) / fx
+    v_norm = (v_grid - cy) / fy
+    norm_square = u_norm**2 + v_norm**2
+    im_depth = im_distance / np.sqrt(norm_square + 1)
+    im_depth = im_depth.astype(dtype)
+
+    return im_depth

--- a/camtools/convert.py
+++ b/camtools/convert.py
@@ -544,9 +544,9 @@ def mesh_to_lineset(
 
 
 def im_distance_to_im_depth(
-    im_distance: Float[np.ndarray, "H W"],
+    im_distance: Float[np.ndarray, "h w"],
     K: Float[np.ndarray, "3 3"],
-) -> Float[np.ndarray, "H W"]:
+) -> Float[np.ndarray, "h w"]:
     """
     Convert distance image to depth image.
 

--- a/camtools/project.py
+++ b/camtools/project.py
@@ -4,6 +4,8 @@ Functions for projecting 2D->3D or 3D->2D.
 
 import cv2
 import numpy as np
+from jaxtyping import Float
+from typing import Union, Tuple, Optional
 
 from . import convert, image, sanity
 
@@ -52,22 +54,27 @@ def point_cloud_to_pixel(points, K, T):
     return pixels
 
 
-def depth_to_point_cloud(
-    im_depth: np.ndarray,
-    K: np.ndarray,
-    T: np.ndarray,
-    im_color: np.ndarray = None,
+def im_depth_to_point_cloud(
+    im_depth: Float[np.ndarray, "H W"],
+    K: Float[np.ndarray, "3 3"],
+    T: Float[np.ndarray, "4 4"],
+    im_color: Optional[Float[np.ndarray, "H W 3"]] = None,
     to_image: bool = False,
     ignore_invalid: bool = True,
     scale_factor: float = 1.0,
-):
+) -> Union[
+    Float[np.ndarray, "N 3"],
+    Float[np.ndarray, "H W 3"],
+    Tuple[Float[np.ndarray, "N 3"], Float[np.ndarray, "N 3"]],
+    Tuple[Float[np.ndarray, "H W 3"], Float[np.ndarray, "H W 3"]],
+]:
     """
     Convert a depth image to a point cloud, optionally including color information.
     Can return either a sparse (N, 3) point cloud or a dense one with the image
     shape (H, W, 3).
 
     Args:
-        im_depth: Depth image (H, W), float32, in world scale.
+        im_depth: Depth image (H, W), float32 or float64, in world scale.
         K: Intrinsics matrix (3, 3).
         T: Extrinsics matrix (4, 4).
         im_color: Color image (H, W, 3), float32/float64, range [0, 1].
@@ -95,8 +102,8 @@ def depth_to_point_cloud(
     sanity.assert_T(T)
     if not isinstance(im_depth, np.ndarray):
         raise TypeError("im_depth must be a numpy array")
-    if im_depth.dtype != np.float32:
-        raise TypeError("im_depth must be of type float32")
+    if im_depth.dtype not in [np.float32, np.float64]:
+        raise TypeError("im_depth must be of type float32 or float64")
     if im_depth.ndim != 2:
         raise ValueError("im_depth must be a 2D array")
     if im_color is not None:

--- a/camtools/project.py
+++ b/camtools/project.py
@@ -10,7 +10,11 @@ from typing import Union, Tuple, Optional
 from . import convert, image, sanity
 
 
-def point_cloud_to_pixel(points, K, T):
+def points_to_pixels(
+    points: Float[np.ndarray, "N 3"],
+    K: Float[np.ndarray, "3 3"],
+    T: Float[np.ndarray, "4 4"],
+) -> Float[np.ndarray, "N 2"]:
     """
     Project points in world coordinates to pixel coordinates.
 

--- a/camtools/project.py
+++ b/camtools/project.py
@@ -59,18 +59,18 @@ def points_to_pixels(
 
 
 def im_depth_to_point_cloud(
-    im_depth: Float[np.ndarray, "H W"],
+    im_depth: Float[np.ndarray, "h w"],
     K: Float[np.ndarray, "3 3"],
     T: Float[np.ndarray, "4 4"],
-    im_color: Optional[Float[np.ndarray, "H W 3"]] = None,
+    im_color: Optional[Float[np.ndarray, "h w 3"]] = None,
     to_image: bool = False,
     ignore_invalid: bool = True,
     scale_factor: float = 1.0,
 ) -> Union[
     Float[np.ndarray, "N 3"],
-    Float[np.ndarray, "H W 3"],
+    Float[np.ndarray, "h w 3"],
     Tuple[Float[np.ndarray, "N 3"], Float[np.ndarray, "N 3"]],
-    Tuple[Float[np.ndarray, "H W 3"], Float[np.ndarray, "H W 3"]],
+    Tuple[Float[np.ndarray, "h w 3"], Float[np.ndarray, "h w 3"]],
 ]:
     """
     Convert a depth image to a point cloud, optionally including color information.

--- a/camtools/project.py
+++ b/camtools/project.py
@@ -11,7 +11,7 @@ from . import convert, image, sanity
 
 
 def points_to_pixels(
-    points: Float[np.ndarray, "N 3"],
+    points: Float[np.ndarray, "n 3"],
     K: Float[np.ndarray, "3 3"],
     T: Float[np.ndarray, "4 4"],
 ) -> Float[np.ndarray, "N 2"]:
@@ -67,9 +67,9 @@ def im_depth_to_point_cloud(
     ignore_invalid: bool = True,
     scale_factor: float = 1.0,
 ) -> Union[
-    Float[np.ndarray, "N 3"],
+    Float[np.ndarray, "n 3"],
     Float[np.ndarray, "h w 3"],
-    Tuple[Float[np.ndarray, "N 3"], Float[np.ndarray, "N 3"]],
+    Tuple[Float[np.ndarray, "n 3"], Float[np.ndarray, "n 3"]],
     Tuple[Float[np.ndarray, "h w 3"], Float[np.ndarray, "h w 3"]],
 ]:
     """

--- a/camtools/raycast.py
+++ b/camtools/raycast.py
@@ -1,6 +1,6 @@
 import numpy as np
 import open3d as o3d
-from jaxtyping import Float, Int
+from jaxtyping import Float
 
 from . import sanity
 from . import convert
@@ -213,7 +213,7 @@ def mesh_to_mask(mesh, K, T, height, width):
     need to perform ray casting of the same mesh multiple times, you should
     create the scene object manually to perform ray casting.
     """
-    im_depth = mesh_to_im_distance(mesh, K, T, height, width)
-    im_mask = (im_depth != np.inf).astype(np.float32)
+    im_distance = mesh_to_im_distance(mesh, K, T, height, width)
+    im_mask = (im_distance != np.inf).astype(np.float32)
 
     return im_mask

--- a/camtools/raycast.py
+++ b/camtools/raycast.py
@@ -48,7 +48,9 @@ def mesh_to_im_distance(
     width: int,
 ):
     """
-    Cast mesh to distance image given camera parameters and image dimensions.
+    Cast mesh to a distance image given camera parameters and image dimensions.
+    Each pixel contains the distance between camera center to the mesh surface.
+    Invalid distances are set to np.inf.
 
     Args:
         mesh: Open3D mesh.
@@ -86,7 +88,8 @@ def mesh_to_im_distances(
 ):
     """
     Cast mesh to distance images given multiple camera parameters and image
-    dimensions. Same as mesh_to_distance, but for multiple cameras.
+    dimensions. Each distance image contains the distance between camera center
+    to the mesh surface. Invalid distances are set to np.inf.
 
     Args:
         mesh: Open3D mesh.

--- a/camtools/solver.py
+++ b/camtools/solver.py
@@ -178,9 +178,9 @@ def point_plane_distance_three_points(point, plane_points):
 
 
 def points_to_mesh_distances(
-    points: Float[np.ndarray, "N 3"],
+    points: Float[np.ndarray, "n 3"],
     mesh: o3d.geometry.TriangleMesh,
-) -> Float[np.ndarray, "N"]:
+) -> Float[np.ndarray, "n"]:
     """
     Compute the distance from points to a mesh surface.
 

--- a/camtools/solver.py
+++ b/camtools/solver.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 from camtools import sanity
+from jaxtyping import Float
+import open3d as o3d
 
 
 def line_intersection_3d(src_points=None, dst_points=None):
@@ -173,3 +175,27 @@ def point_plane_distance_three_points(point, plane_points):
     # Ref: https://mathworld.wolfram.com/Point-PlaneDistance.html
     distance = np.abs(np.dot(plane_n, point - plane_a))
     return distance
+
+
+def points_to_mesh_distances(
+    points: Float[np.ndarray, "N 3"],
+    mesh: o3d.geometry.TriangleMesh,
+) -> Float[np.ndarray, "N"]:
+    """
+    Compute the distance from points to a mesh surface.
+
+    Args:
+        points (np.ndarray): Array of points with shape (N, 3).
+        mesh (o3d.geometry.TriangleMesh): The input mesh.
+
+    Returns:
+        np.ndarray: Array of distances with shape (N,).
+    """
+    if not points.ndim == 2 or points.shape[1] != 3:
+        raise ValueError(f"Expected points of shape (N, 3), but got {points.shape}.")
+    mesh_t = o3d.t.geometry.TriangleMesh.from_legacy(mesh)
+    scene = o3d.t.geometry.RaycastingScene()
+    _ = scene.add_triangles(mesh_t)
+    points_tensor = o3d.core.Tensor(points, dtype=o3d.core.Dtype.Float32)
+    distances = scene.compute_distance(points_tensor)
+    return distances.numpy()

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -513,8 +513,8 @@ def test_union_of_hints():
     def identity(
         arr: Union[
             Float[Tensor, "3 4"],
-            Float[Tensor, "N 3 4"],
-            Int[Tensor, "N 3 4"],
+            Float[Tensor, "n 3 4"],
+            Int[Tensor, "n 3 4"],
         ]
     ):
         return arr

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -1,0 +1,51 @@
+import numpy as np
+import open3d as o3d
+import matplotlib.pyplot as plt
+import camtools as ct
+
+
+def test_mesh_to_depth():
+    sphere = o3d.geometry.TriangleMesh.create_sphere(radius=1.0)
+    box = o3d.geometry.TriangleMesh.create_box(width=1.5, height=1.5, depth=1.5)
+    sphere.compute_vertex_normals()
+    box.compute_vertex_normals()
+
+    # Move the geometries
+    sphere.translate([0, 0, 4])
+    box.translate([0, 0, 4])
+
+    # Combine the geometries
+    mesh = sphere + box
+
+    # Create dummy camera intrinsics (K)
+    width, height = 640, 480
+    fx, fy = 500, 500
+    cx, cy = width / 2, height / 2
+    K = np.array([[fx, 0, cx], [0, fy, cy], [0, 0, 1]])
+    T = np.eye(4)
+
+    # axes = o3d.geometry.TriangleMesh.create_coordinate_frame(size=1.0)
+    # camera_frustum = ct.camera.create_camera_frustums([K], [T], size=1)
+    # o3d.visualization.draw_geometries([camera_frustum, mesh, axes])
+
+    # Call mesh_to_depth function
+    im_depth = ct.raycast.mesh_to_depth(mesh, K, T, height, width)
+
+    # Convert depth image to point cloud
+    points = ct.project.depth_to_point_cloud(im_depth, K, T)
+
+    # Create Open3D point cloud
+    pcd = o3d.geometry.PointCloud()
+    pcd.points = o3d.utility.Vector3dVector(points)
+
+    # Visualize the point cloud along with the original meshes
+    o3d.visualization.draw_geometries([pcd, mesh])
+
+    # Plot the depth image (optional, you can keep or remove this part)
+    plt.figure(figsize=(10, 7.5))
+    plt.imshow(im_depth, cmap="viridis")
+    plt.colorbar(label="Depth")
+    plt.title("Depth Image")
+    plt.xlabel("Pixel X")
+    plt.ylabel("Pixel Y")
+    plt.show()

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -1,23 +1,19 @@
 import numpy as np
 import open3d as o3d
-import matplotlib.pyplot as plt
-import camtools as ct
 
-from jaxtyping import Float
+import camtools as ct
 
 
 def test_mesh_to_depth():
     # Geometries
     sphere = o3d.geometry.TriangleMesh.create_sphere(radius=1.0)
+    sphere = sphere.translate([0, 0, 4])
     box = o3d.geometry.TriangleMesh.create_box(width=1.5, height=1.5, depth=1.5)
-    sphere.translate([0, 0, 4])
-    box.translate([0, 0, 4])
-    sphere.compute_vertex_normals()
-    box.compute_vertex_normals()
+    box = box.translate([0, 0, 4])
     mesh = sphere + box
     lineset = ct.convert.mesh_to_lineset(mesh)
 
-    # Camera K and T
+    # Camera
     width, height = 640, 480
     fx, fy = 500, 500
     cx, cy = width / 2, height / 2
@@ -25,26 +21,27 @@ def test_mesh_to_depth():
     T = np.eye(4)
     camera_frustum = ct.camera.create_camera_frustums([K], [T], size=1)
 
-    # mesh -> depth
+    # 3D -> 2D -> 3D projection (mesh -> depth -> points)
     im_depth = ct.raycast.mesh_to_im_depth(mesh, K, T, height, width)
     points = ct.project.im_depth_to_point_cloud(im_depth, K, T)
 
-    # Compute distances
-    distances = ct.solver.points_to_mesh_distances(points, mesh)
-    assert np.max(distances) < 5e-3
-    print(f"distances: max {np.max(distances)}, avg {np.mean(distances)}")
+    # Verify points are on the mesh surface
+    points_to_mesh_distances = ct.solver.points_to_mesh_distances(points, mesh)
+    assert np.max(points_to_mesh_distances) < 5e-3
 
-    # Visualize
-    pcd = o3d.geometry.PointCloud()
-    pcd.points = o3d.utility.Vector3dVector(points)
-    axes = o3d.geometry.TriangleMesh.create_coordinate_frame(size=1)
-    o3d.visualization.draw_geometries([pcd, lineset, camera_frustum, axes])
+    visualize = False
+    if visualize:
+        import matplotlib.pyplot as plt
 
-    # Plot the depth image (optional, you can keep or remove this part)
-    plt.figure(figsize=(10, 7.5))
-    plt.imshow(im_depth, cmap="viridis")
-    plt.colorbar(label="Depth")
-    plt.title("Depth Image")
-    plt.xlabel("Pixel X")
-    plt.ylabel("Pixel Y")
-    plt.show()
+        pcd = o3d.geometry.PointCloud()
+        pcd.points = o3d.utility.Vector3dVector(points)
+        axes = o3d.geometry.TriangleMesh.create_coordinate_frame(size=1)
+        o3d.visualization.draw_geometries([pcd, lineset, camera_frustum, axes])
+
+        plt.figure(figsize=(10, 7.5))
+        plt.imshow(im_depth, cmap="viridis")
+        plt.colorbar(label="Depth")
+        plt.title("Depth Image")
+        plt.xlabel("Pixel X")
+        plt.ylabel("Pixel Y")
+        plt.show()

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -76,7 +76,7 @@ def test_mesh_to_depth():
     im_depth = distance_to_depth(im_distance, K).astype(np.float32)
 
     # z-depth -> points
-    points = ct.project.depth_to_point_cloud(im_depth, K, T)
+    points = ct.project.im_depth_to_point_cloud(im_depth, K, T)
 
     # Compute distances
     distances = point_to_mesh_distance(points, mesh)

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -33,23 +33,6 @@ def point_to_mesh_distance(points, mesh):
     return distances.numpy()
 
 
-def distance_to_depth(im_distance, K):
-    height, width = im_distance.shape
-    fx, fy = K[0, 0], K[1, 1]
-    cx, cy = K[0, 2], K[1, 2]
-
-    u = np.arange(width)
-    v = np.arange(height)
-    u_grid, v_grid = np.meshgrid(u, v)
-
-    u_norm = (u_grid - cx) / fx
-    v_norm = (v_grid - cy) / fy
-    norm_square = u_norm**2 + v_norm**2
-    z_depth = im_distance / np.sqrt(norm_square + 1)
-
-    return z_depth
-
-
 def test_mesh_to_depth():
     # Geometries
     sphere = o3d.geometry.TriangleMesh.create_sphere(radius=1.0)
@@ -73,7 +56,7 @@ def test_mesh_to_depth():
     im_distance = ct.raycast.mesh_to_im_distance(mesh, K, T, height, width)
 
     # Convert distance to depth
-    im_depth = distance_to_depth(im_distance, K).astype(np.float32)
+    im_depth = ct.convert.im_distance_to_im_depth(im_distance, K).astype(np.float32)
 
     # z-depth -> points
     points = ct.project.im_depth_to_point_cloud(im_depth, K, T)

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -1,6 +1,5 @@
 import numpy as np
 import open3d as o3d
-
 import camtools as ct
 
 

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -60,13 +60,13 @@ def test_mesh_to_depth():
     camera_frustum = ct.camera.create_camera_frustums([K], [T], size=2)
 
     # mesh -> depth
-    im_distance_depth = ct.raycast.mesh_to_depth(mesh, K, T, height, width)
+    im_distance = ct.raycast.mesh_to_distance(mesh, K, T, height, width)
 
     # Convert distance depth to z-depth
-    im_z_depth = distance_to_z_depth(im_distance_depth, K)
+    im_depth = distance_to_z_depth(im_distance, K)
 
     # z-depth -> points
-    points = ct.project.depth_to_point_cloud(im_z_depth, K, T)
+    points = ct.project.depth_to_point_cloud(im_depth, K, T)
 
     # Visualize
     pcd = o3d.geometry.PointCloud()

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -70,7 +70,7 @@ def test_mesh_to_depth():
     camera_frustum = ct.camera.create_camera_frustums([K], [T], size=2)
 
     # mesh -> depth
-    im_distance = ct.raycast.mesh_to_distance(mesh, K, T, height, width)
+    im_distance = ct.raycast.mesh_to_im_distance(mesh, K, T, height, width)
 
     # Convert distance to depth
     im_depth = distance_to_depth(im_distance, K).astype(np.float32)
@@ -80,12 +80,14 @@ def test_mesh_to_depth():
 
     # Compute distances
     distances = point_to_mesh_distance(points, mesh)
+    assert np.max(distances) < 5e-3
+    assert np.mean(distances) < 1e-3
     print(f"distances: max {np.max(distances)}, avg {np.mean(distances)}")
 
     # Visualize
     pcd = o3d.geometry.PointCloud()
     pcd.points = o3d.utility.Vector3dVector(points)
-    axes = o3d.geometry.TriangleMesh.create_coordinate_frame(size=0.5)
+    axes = o3d.geometry.TriangleMesh.create_coordinate_frame(size=1)
     o3d.visualization.draw_geometries([pcd, lineset, camera_frustum, axes])
 
     # # Plot the depth image (optional, you can keep or remove this part)

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -5,108 +5,7 @@ import camtools as ct
 from codetiming import Timer
 
 
-def mesh_to_lineset(mesh: o3d.geometry.TriangleMesh) -> o3d.geometry.LineSet:
-    # Extract vertices and triangles from the mesh
-    vertices = np.asarray(mesh.vertices)
-    triangles = np.asarray(mesh.triangles)
-
-    # Create edges from triangles
-    edges = set()
-    for triangle in triangles:
-        edges.add(tuple(sorted([triangle[0], triangle[1]])))
-        edges.add(tuple(sorted([triangle[1], triangle[2]])))
-        edges.add(tuple(sorted([triangle[2], triangle[0]])))
-
-    # Convert edges to a numpy array
-    edges = np.array(list(edges))
-
-    # Create a LineSet
-    line_set = o3d.geometry.LineSet()
-    line_set.points = o3d.utility.Vector3dVector(vertices)
-    line_set.lines = o3d.utility.Vector2iVector(edges)
-
-    return line_set
-
-
-@Timer(name="distance_to_depth_v1")
-def distance_to_depth_v1(im_distance, K):
-    """
-    Convert distance depth to z-depth.
-
-    Args:
-        im_distance (np.ndarray): Distance image.
-        K (np.ndarray): Camera intrinsic matrix.
-
-    Returns:
-        np.ndarray: Z-depth image.
-    """
-    # Extract focal lengths and principal points from K
-    fx, fy = K[0, 0], K[1, 1]
-    cx, cy = K[0, 2], K[1, 2]
-
-    # Calculate pixel coordinates
-    height, width = im_distance.shape
-    y, x = np.mgrid[0:height, 0:width]
-
-    # Calculate normalized pixel coordinates
-    x_norm = (x - cx) / fx
-    y_norm = (y - cy) / fy
-
-    # Calculate z-depth
-    z_depth = im_distance / np.sqrt(1 + x_norm**2 + y_norm**2)
-
-    return z_depth
-
-
-@Timer(name="distance_to_depth_v2")
-def distance_to_depth_v2(im_distance, K):
-    height, width = im_distance.shape
-    fx, fy = K[0, 0], K[1, 1]
-    cx, cy = K[0, 2], K[1, 2]
-
-    u = np.arange(width)
-    v = np.arange(height)
-    u_grid, v_grid = np.meshgrid(u, v)
-
-    u_norm = (u_grid - cx) / fx
-    v_norm = (v_grid - cy) / fy
-    norm_square = u_norm**2 + v_norm**2
-    z_depth = im_distance / np.sqrt(norm_square + 1)
-
-    return z_depth
-
-
-@Timer(name="distance_to_depth_v3")
-def distance_to_depth_v3(im_distance, K):
-    """
-    from marigold
-    """
-    # Extract focal length from K (assuming fx = fy)
-    flt_focal = K[0, 0]
-
-    # Get height and width from the distance array
-    height, width = im_distance.shape
-
-    img_plane_x = (
-        np.linspace((-0.5 * width) + 0.5, (0.5 * width) - 0.5, width)
-        .reshape(1, width)
-        .repeat(height, 0)
-        .astype(np.float32)[:, :, None]
-    )
-    img_plane_y = (
-        np.linspace((-0.5 * height) + 0.5, (0.5 * height) - 0.5, height)
-        .reshape(height, 1)
-        .repeat(width, 1)
-        .astype(np.float32)[:, :, None]
-    )
-    img_plane_z = np.full([height, width, 1], flt_focal, np.float32)
-    img_plane = np.concatenate([img_plane_x, img_plane_y, img_plane_z], 2)
-
-    depth = im_distance / np.linalg.norm(img_plane, 2, 2) * flt_focal
-    return depth
-
-
-def compute_point_to_mesh_distance(points, mesh):
+def point_to_mesh_distance(points, mesh):
     """
     Compute the distance from points to a mesh surface.
 
@@ -160,7 +59,7 @@ def test_mesh_to_depth():
     sphere.compute_vertex_normals()
     box.compute_vertex_normals()
     mesh = sphere + box
-    lineset = mesh_to_lineset(mesh)
+    lineset = ct.convert.mesh_to_lineset(mesh)
 
     # Camera K and T
     width, height = 640, 480
@@ -180,7 +79,7 @@ def test_mesh_to_depth():
     points = ct.project.depth_to_point_cloud(im_depth, K, T)
 
     # Compute distances
-    distances = compute_point_to_mesh_distance(points, mesh)
+    distances = point_to_mesh_distance(points, mesh)
     print(f"distances: max {np.max(distances)}, avg {np.mean(distances)}")
 
     # Visualize

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -62,18 +62,18 @@ def distance_to_depth_v1(im_distance, K):
 @Timer(name="distance_to_depth_v2")
 def distance_to_depth_v2(im_distance, K):
     height, width = im_distance.shape
+    fx, fy = K[0, 0], K[1, 1]
+    cx, cy = K[0, 2], K[1, 2]
+
     u = np.arange(width)
     v = np.arange(height)
     u_grid, v_grid = np.meshgrid(u, v)
 
-    fx = K[0, 0]
-    fy = K[1, 1]
-    cx = K[0, 2]
-    cy = K[1, 2]
     u_norm = (u_grid - cx) / fx
     v_norm = (v_grid - cy) / fy
     norm_square = u_norm**2 + v_norm**2
     z_depth = im_distance / np.sqrt(norm_square + 1)
+
     return z_depth
 
 

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -98,8 +98,3 @@ def test_mesh_to_depth():
     # plt.xlabel("Pixel X")
     # plt.ylabel("Pixel Y")
     # plt.show()
-
-
-# Run the test function if this script is executed directly
-if __name__ == "__main__":
-    test_mesh_to_depth()

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -4,29 +4,29 @@ import matplotlib.pyplot as plt
 import camtools as ct
 
 
-def distance_to_z_depth(distance_depth, K):
+def distance_to_depth(im_distance, K):
     """
     Convert distance depth to z-depth.
 
     Args:
-        distance_depth (np.ndarray): Distance depth image.
+        im_distance (np.ndarray): Distance image.
         K (np.ndarray): Camera intrinsic matrix.
 
     Returns:
         np.ndarray: Z-depth image.
     """
     # Create a mask for valid depth values
-    valid_mask = distance_depth > 0
+    valid_mask = im_distance > 0
 
     # Initialize z_depth with the same shape as distance_depth
-    z_depth = np.zeros_like(distance_depth)
+    z_depth = np.zeros_like(im_distance)
 
     # Extract focal lengths and principal points from K
     fx, fy = K[0, 0], K[1, 1]
     cx, cy = K[0, 2], K[1, 2]
 
     # Calculate pixel coordinates
-    height, width = distance_depth.shape
+    height, width = im_distance.shape
     y, x = np.mgrid[0:height, 0:width]
 
     # Calculate normalized pixel coordinates
@@ -34,7 +34,7 @@ def distance_to_z_depth(distance_depth, K):
     y_norm = (y - cy) / fy
 
     # Calculate z-depth for valid pixels
-    z_depth[valid_mask] = distance_depth[valid_mask] / np.sqrt(
+    z_depth[valid_mask] = im_distance[valid_mask] / np.sqrt(
         1 + x_norm[valid_mask] ** 2 + y_norm[valid_mask] ** 2
     )
 
@@ -91,7 +91,7 @@ def test_mesh_to_depth():
     im_distance = ct.raycast.mesh_to_distance(mesh, K, T, height, width)
 
     # Convert distance depth to z-depth
-    im_depth = distance_to_z_depth(im_distance, K)
+    im_depth = distance_to_depth(im_distance, K)
 
     # z-depth -> points
     points = ct.project.depth_to_point_cloud(im_depth, K, T)

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -5,47 +5,40 @@ import camtools as ct
 
 
 def test_mesh_to_depth():
+    # Geometries
     sphere = o3d.geometry.TriangleMesh.create_sphere(radius=1.0)
     box = o3d.geometry.TriangleMesh.create_box(width=1.5, height=1.5, depth=1.5)
+    sphere.translate([0, 0, 2])
+    box.translate([0, 0, 2])
     sphere.compute_vertex_normals()
     box.compute_vertex_normals()
-
-    # Move the geometries
-    sphere.translate([0, 0, 4])
-    box.translate([0, 0, 4])
-
-    # Combine the geometries
     mesh = sphere + box
 
-    # Create dummy camera intrinsics (K)
+    # Camera K and T
     width, height = 640, 480
     fx, fy = 500, 500
     cx, cy = width / 2, height / 2
     K = np.array([[fx, 0, cx], [0, fy, cy], [0, 0, 1]])
     T = np.eye(4)
+    camera_frustum = ct.camera.create_camera_frustums([K], [T], size=0.5)
 
-    # axes = o3d.geometry.TriangleMesh.create_coordinate_frame(size=1.0)
-    # camera_frustum = ct.camera.create_camera_frustums([K], [T], size=1)
-    # o3d.visualization.draw_geometries([camera_frustum, mesh, axes])
-
-    # Call mesh_to_depth function
+    # mesh -> depth
     im_depth = ct.raycast.mesh_to_depth(mesh, K, T, height, width)
 
-    # Convert depth image to point cloud
+    # depth -> points
     points = ct.project.depth_to_point_cloud(im_depth, K, T)
 
-    # Create Open3D point cloud
+    # Visualize
     pcd = o3d.geometry.PointCloud()
     pcd.points = o3d.utility.Vector3dVector(points)
+    axes = o3d.geometry.TriangleMesh.create_coordinate_frame(size=0.5)
+    o3d.visualization.draw_geometries([pcd, mesh, camera_frustum, axes])
 
-    # Visualize the point cloud along with the original meshes
-    o3d.visualization.draw_geometries([pcd, mesh])
-
-    # Plot the depth image (optional, you can keep or remove this part)
-    plt.figure(figsize=(10, 7.5))
-    plt.imshow(im_depth, cmap="viridis")
-    plt.colorbar(label="Depth")
-    plt.title("Depth Image")
-    plt.xlabel("Pixel X")
-    plt.ylabel("Pixel Y")
-    plt.show()
+    # # Plot the depth image (optional, you can keep or remove this part)
+    # plt.figure(figsize=(10, 7.5))
+    # plt.imshow(im_depth, cmap="viridis")
+    # plt.colorbar(label="Depth")
+    # plt.title("Depth Image")
+    # plt.xlabel("Pixel X")
+    # plt.ylabel("Pixel Y")
+    # plt.show()

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -173,16 +173,14 @@ def test_mesh_to_depth():
     points_v2 = ct.project.depth_to_point_cloud(im_depth_v2, K, T)
     points_v3 = ct.project.depth_to_point_cloud(im_depth_v3, K, T)
 
-    # # Compute distances
-    # distances_v1 = compute_point_to_mesh_distance(points_v1, mesh)
-    # distances_v2 = compute_point_to_mesh_distance(points_v2, mesh)
-    # distances_v3 = compute_point_to_mesh_distance(points_v3, mesh)
+    # Compute distances
+    distances_v1 = compute_point_to_mesh_distance(points_v1, mesh)
+    distances_v2 = compute_point_to_mesh_distance(points_v2, mesh)
+    distances_v3 = compute_point_to_mesh_distance(points_v3, mesh)
 
-    # # Assert that all points are close to the mesh surface
-    # threshold = 1e-3  # 1 mm threshold, adjust as needed
-    # assert np.all(
-    #     distances < threshold
-    # ), f"Some points are not on the mesh surface. Max distance: {np.max(distances)}"
+    print(f"distances_v1: max {np.max(distances_v1)}, avg {np.mean(distances_v1)}")
+    print(f"distances_v2: max {np.max(distances_v2)}, avg {np.mean(distances_v2)}")
+    print(f"distances_v3: max {np.max(distances_v3)}, avg {np.mean(distances_v3)}")
 
     # Visualize
     pcd_v1 = o3d.geometry.PointCloud()

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -10,8 +10,8 @@ def test_mesh_to_depth():
     # Geometries
     sphere = o3d.geometry.TriangleMesh.create_sphere(radius=1.0)
     box = o3d.geometry.TriangleMesh.create_box(width=1.5, height=1.5, depth=1.5)
-    sphere.translate([0, 0, 2])
-    box.translate([0, 0, 2])
+    sphere.translate([0, 0, 4])
+    box.translate([0, 0, 4])
     sphere.compute_vertex_normals()
     box.compute_vertex_normals()
     mesh = sphere + box
@@ -23,7 +23,7 @@ def test_mesh_to_depth():
     cx, cy = width / 2, height / 2
     K = np.array([[fx, 0, cx], [0, fy, cy], [0, 0, 1]])
     T = np.eye(4)
-    camera_frustum = ct.camera.create_camera_frustums([K], [T], size=2)
+    camera_frustum = ct.camera.create_camera_frustums([K], [T], size=1)
 
     # mesh -> depth
     im_depth = ct.raycast.mesh_to_im_depth(mesh, K, T, height, width)
@@ -32,7 +32,6 @@ def test_mesh_to_depth():
     # Compute distances
     distances = ct.solver.points_to_mesh_distances(points, mesh)
     assert np.max(distances) < 5e-3
-    assert np.mean(distances) < 1e-3
     print(f"distances: max {np.max(distances)}, avg {np.mean(distances)}")
 
     # Visualize
@@ -41,11 +40,11 @@ def test_mesh_to_depth():
     axes = o3d.geometry.TriangleMesh.create_coordinate_frame(size=1)
     o3d.visualization.draw_geometries([pcd, lineset, camera_frustum, axes])
 
-    # # Plot the depth image (optional, you can keep or remove this part)
-    # plt.figure(figsize=(10, 7.5))
-    # plt.imshow(im_depth, cmap="viridis")
-    # plt.colorbar(label="Depth")
-    # plt.title("Depth Image")
-    # plt.xlabel("Pixel X")
-    # plt.ylabel("Pixel Y")
-    # plt.show()
+    # Plot the depth image (optional, you can keep or remove this part)
+    plt.figure(figsize=(10, 7.5))
+    plt.imshow(im_depth, cmap="viridis")
+    plt.colorbar(label="Depth")
+    plt.title("Depth Image")
+    plt.xlabel("Pixel X")
+    plt.ylabel("Pixel Y")
+    plt.show()

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -26,12 +26,7 @@ def test_mesh_to_depth():
     camera_frustum = ct.camera.create_camera_frustums([K], [T], size=2)
 
     # mesh -> depth
-    im_distance = ct.raycast.mesh_to_im_distance(mesh, K, T, height, width)
-
-    # Convert distance to depth
-    im_depth = ct.convert.im_distance_to_im_depth(im_distance, K).astype(np.float32)
-
-    # z-depth -> points
+    im_depth = ct.raycast.mesh_to_im_depth(mesh, K, T, height, width)
     points = ct.project.im_depth_to_point_cloud(im_depth, K, T)
 
     # Compute distances

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -2,35 +2,8 @@ import numpy as np
 import open3d as o3d
 import matplotlib.pyplot as plt
 import camtools as ct
-from codetiming import Timer
 
-
-def point_to_mesh_distance(points, mesh):
-    """
-    Compute the distance from points to a mesh surface.
-
-    Args:
-        points (np.ndarray): Array of points with shape (N, 3).
-        mesh (o3d.geometry.TriangleMesh): The input mesh.
-
-    Returns:
-        np.ndarray: Array of distances with shape (N,).
-    """
-    # Convert the legacy mesh to o3d.t.geometry.TriangleMesh
-    mesh_t = o3d.t.geometry.TriangleMesh.from_legacy(mesh)
-
-    # Create a RaycastingScene and add the triangle mesh
-    scene = o3d.t.geometry.RaycastingScene()
-    _ = scene.add_triangles(mesh_t)
-
-    # Convert points to o3d.core.Tensor
-    points_tensor = o3d.core.Tensor(points, dtype=o3d.core.Dtype.Float32)
-
-    # Compute the unsigned distance from the points to the mesh surface
-    distances = scene.compute_distance(points_tensor)
-
-    # Convert distances to numpy array
-    return distances.numpy()
+from jaxtyping import Float
 
 
 def test_mesh_to_depth():
@@ -62,7 +35,7 @@ def test_mesh_to_depth():
     points = ct.project.im_depth_to_point_cloud(im_depth, K, T)
 
     # Compute distances
-    distances = point_to_mesh_distance(points, mesh)
+    distances = ct.solver.points_to_mesh_distances(points, mesh)
     assert np.max(distances) < 5e-3
     assert np.mean(distances) < 1e-3
     print(f"distances: max {np.max(distances)}, avg {np.mean(distances)}")

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -4,6 +4,43 @@ import matplotlib.pyplot as plt
 import camtools as ct
 
 
+def distance_to_z_depth(distance_depth, K):
+    """
+    Convert distance depth to z-depth.
+
+    Args:
+        distance_depth (np.ndarray): Distance depth image.
+        K (np.ndarray): Camera intrinsic matrix.
+
+    Returns:
+        np.ndarray: Z-depth image.
+    """
+    # Create a mask for valid depth values
+    valid_mask = distance_depth > 0
+
+    # Initialize z_depth with the same shape as distance_depth
+    z_depth = np.zeros_like(distance_depth)
+
+    # Extract focal lengths and principal points from K
+    fx, fy = K[0, 0], K[1, 1]
+    cx, cy = K[0, 2], K[1, 2]
+
+    # Calculate pixel coordinates
+    height, width = distance_depth.shape
+    y, x = np.mgrid[0:height, 0:width]
+
+    # Calculate normalized pixel coordinates
+    x_norm = (x - cx) / fx
+    y_norm = (y - cy) / fy
+
+    # Calculate z-depth for valid pixels
+    z_depth[valid_mask] = distance_depth[valid_mask] / np.sqrt(
+        1 + x_norm[valid_mask] ** 2 + y_norm[valid_mask] ** 2
+    )
+
+    return z_depth
+
+
 def test_mesh_to_depth():
     # Geometries
     sphere = o3d.geometry.TriangleMesh.create_sphere(radius=1.0)
@@ -20,13 +57,16 @@ def test_mesh_to_depth():
     cx, cy = width / 2, height / 2
     K = np.array([[fx, 0, cx], [0, fy, cy], [0, 0, 1]])
     T = np.eye(4)
-    camera_frustum = ct.camera.create_camera_frustums([K], [T], size=0.5)
+    camera_frustum = ct.camera.create_camera_frustums([K], [T], size=2)
 
     # mesh -> depth
-    im_depth = ct.raycast.mesh_to_depth(mesh, K, T, height, width)
+    im_distance_depth = ct.raycast.mesh_to_depth(mesh, K, T, height, width)
 
-    # depth -> points
-    points = ct.project.depth_to_point_cloud(im_depth, K, T)
+    # Convert distance depth to z-depth
+    im_z_depth = distance_to_z_depth(im_distance_depth, K)
+
+    # z-depth -> points
+    points = ct.project.depth_to_point_cloud(im_z_depth, K, T)
 
     # Visualize
     pcd = o3d.geometry.PointCloud()


### PR DESCRIPTION
## Summary

- Previously, the terminology of depth (as in z-depth) and distance (as in the Euclidean distance between a 3D point to the camera center) were mixed-used. This PR clarifies and standardizes the terminology to avoid confusion.
- Use `im_depth` or `im_distance` in function signatures when referring to depth images or distance images, respectively.
- Added conversion between distance image to depth image: `ct.convert.im_distance_to_im_depth` and `ct.convert.im_depth_to_im_distance`.

## TL;DR

- Depth image refers to z-depth image. That is, the z coordinate after projecting a 3D point to the camera coordinate.
- Distance image refers to an image showing the Euclidean distance between each 3D point and the camera center.

## API Changes

### Added (or renamed as)
- `ct.raycast.mesh_to_im_depth`: new
- `ct.raycast.mesh_to_im_depths`: new
- `ct.raycast.mesh_to_im_distance`: refactored to this
- `ct.raycast.mesh_to_im_distances`: refactored to this
- `ct.convert.im_depth_to_im_distance`: new
- `ct.convert.im_distance_to_im_depth`: new
- `ct.convert.mesh_to_lineset`: new
- `ct.solver.points_to_mesh_distances`: new
- `ct.project.points_to_pixels`: refactored to this
- `ct.project.im_depth_to_point_cloud`: refactored to this

### Removed
- `ct.raycast.mesh_to_depth`
- `ct.raycast.mesh_to_depths`
- `ct.project.point_cloud_to_pixel`
- `ct.project.depth_to_point_cloud`

## Examples

Given a triangle mesh and camera parameters, we:
- ray cast the mesh to 2D depth image (`ct.raycast.mesh_to_im_depth`), and
- back project the 2D depth image into 3D point cloud (`ct.project.im_depth_to_point_cloud`), where the point cloud shall match the mesh surface,

```python
import numpy as np
import open3d as o3d
import camtools as ct
import matplotlib.pyplot as plt

# Geometries
sphere = o3d.geometry.TriangleMesh.create_sphere(radius=1.0)
sphere = sphere.translate([0, 0, 4])
box = o3d.geometry.TriangleMesh.create_box(width=1.5, height=1.5, depth=1.5)
box = box.translate([0, 0, 4])
mesh = sphere + box
lineset = ct.convert.mesh_to_lineset(mesh)

# Camera
width, height = 640, 480
fx, fy = 500, 500
cx, cy = width / 2, height / 2
K = np.array([[fx, 0, cx], [0, fy, cy], [0, 0, 1]])
T = np.eye(4)
camera_frustum = ct.camera.create_camera_frustums([K], [T], size=1)

# 3D -> 2D -> 3D projection (mesh -> depth -> points)
im_depth = ct.raycast.mesh_to_im_depth(mesh, K, T, height, width)
points = ct.project.im_depth_to_point_cloud(im_depth, K, T)

# Visualization
pcd = o3d.geometry.PointCloud()
pcd.points = o3d.utility.Vector3dVector(points)
axes = o3d.geometry.TriangleMesh.create_coordinate_frame(size=1)
o3d.visualization.draw_geometries([pcd, lineset, camera_frustum, axes])

plt.figure(figsize=(10, 7.5))
plt.imshow(im_depth, cmap="viridis")
plt.colorbar(label="Depth")
plt.title("Depth Image")
plt.xlabel("Pixel X")
plt.ylabel("Pixel Y")
plt.show()
```

<p align="center">
<img src="https://github.com/user-attachments/assets/fb78c2fc-b10d-495b-a15f-41d3b4297b39" alt="plot_3d" width="600"/>
<img src="https://github.com/user-attachments/assets/eecfa411-9df5-4efe-9b38-0d6350773f6f" alt="plot_2d_depth" width="600"/>
</p>