### PR TITLE
fix: use numpy 1.x for now to avoid segfault with open3d

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 dependencies = [
-  "numpy>=1.15.0",
+  "numpy>=1.15.0,<=1.26.4",
   "open3d>=0.16.0",
   "opencv-python>=4.5.1.48",
   "matplotlib>=3.3.4",


### PR DESCRIPTION
- See: https://github.com/isl-org/Open3D/issues/6840
- This will likely be resolved at Open3D 0.19 release: https://github.com/isl-org/Open3D/issues/6840#issuecomment-2231637165, when well shall remove this restriction on numpy 1.x.