### PR TITLE
test(render): add tests for geometry rendering and depth validation

### DIFF
--- a/camtools/render.py
+++ b/camtools/render.py
@@ -40,6 +40,7 @@ def render_geometries(
             The radius is in world metric space, not relative pixel space like
             the point size.
         to_depth: bool whether to render a depth image instead of RGB image.
+            Invalid depth or infinite depth is set to 0.
         visible: bool whether to show the window.
 
     Returns:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,17 @@
 import pytest
+import open3d as o3d
+
+
+@pytest.fixture
+def has_display():
+    """Check if display is available for Open3D visualization."""
+    try:
+        # Try to create a visualizer to check if display is available
+        vis = o3d.visualization.Visualizer()
+        vis.destroy_window()
+        return True
+    except Exception:
+        return False
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,16 +1,50 @@
 import pytest
+import open3d as o3d
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "skip_no_display: skip test when no display is available"
+    )
+
+
+@pytest.fixture
+def has_display():
+    """F
+    Fixture to check if display is available for Open3D visualization.
+    """
+    try:
+        vis = o3d.visualization.Visualizer()
+        vis.destroy_window()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def skip_no_display(request, has_display):
+    """
+    Automatically skip tests marked with skip_no_display when display isn't
+    available.
+    """
+    if request.node.get_closest_marker("skip_no_display"):
+        if not has_display:
+            pytest.skip("Test skipped: no display available")
 
 
 @pytest.fixture
 def visualize(request):
-    """Fixture to control visualization in tests.
+    """
+    Fixture to control visualization in tests.
     Can be overridden via command line: pytest --visualize
     """
     return request.config.getoption("--visualize")
 
 
 def pytest_addoption(parser):
-    """Add visualize option to pytest command line arguments"""
+    """
+    Add visualize option to pytest command line arguments
+    """
     parser.addoption(
         "--visualize",
         action="store_true",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,17 +1,4 @@
 import pytest
-import open3d as o3d
-
-
-@pytest.fixture
-def has_display():
-    """Check if display is available for Open3D visualization."""
-    try:
-        # Try to create a visualizer to check if display is available
-        vis = o3d.visualization.Visualizer()
-        vis.destroy_window()
-        return True
-    except Exception:
-        return False
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,12 +9,18 @@ def pytest_configure(config):
 
 
 @pytest.fixture
-def has_display():
-    """F
-    Fixture to check if display is available for Open3D visualization.
+def has_o3d_display():
+    """
+    Fixture to check if Open3D visualization display is available.
     """
     try:
+        # Create window with minimal size and hidden
         vis = o3d.visualization.Visualizer()
+        vis.create_window(width=1, height=1, visible=False)
+        # Check if view control is available
+        if vis.get_view_control() is None:
+            vis.destroy_window()
+            return False
         vis.destroy_window()
         return True
     except Exception:
@@ -22,14 +28,14 @@ def has_display():
 
 
 @pytest.fixture(autouse=True)
-def skip_no_display(request, has_display):
+def skip_no_o3d_display(request, has_o3d_display):
     """
-    Automatically skip tests marked with skip_no_display when display isn't
-    available.
+    Automatically skip tests marked with skip_no_display when Open3D visualization
+    isn't available.
     """
     if request.node.get_closest_marker("skip_no_display"):
-        if not has_display:
-            pytest.skip("Test skipped: no display available")
+        if not has_o3d_display:
+            pytest.skip("Test skipped: no Open3D display available")
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,7 +4,7 @@ import open3d as o3d
 
 def pytest_configure(config):
     config.addinivalue_line(
-        "markers", "skip_no_display: skip test when no display is available"
+        "markers", "skip_no_o3d_display: skip test when no display is available"
     )
 
 
@@ -28,10 +28,10 @@ def has_o3d_display():
 @pytest.fixture(autouse=True)
 def skip_no_o3d_display(request, has_o3d_display):
     """
-    Automatically skip tests marked with skip_no_display when Open3D visualization
+    Automatically skip tests marked with skip_no_o3d_display when Open3D visualization
     isn't available.
     """
-    if request.node.get_closest_marker("skip_no_display"):
+    if request.node.get_closest_marker("skip_no_o3d_display"):
         if not has_o3d_display:
             pytest.skip("Test skipped: no Open3D display available")
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,10 +14,8 @@ def has_o3d_display():
     Fixture to check if Open3D visualization display is available.
     """
     try:
-        # Create window with minimal size and hidden
         vis = o3d.visualization.Visualizer()
         vis.create_window(width=1, height=1, visible=False)
-        # Check if view control is available
         if vis.get_view_control() is None:
             vis.destroy_window()
             return False

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+@pytest.fixture
+def visualize(request):
+    """Fixture to control visualization in tests.
+    Can be overridden via command line: pytest --visualize
+    """
+    return request.config.getoption("--visualize")
+
+
+def pytest_addoption(parser):
+    """Add visualize option to pytest command line arguments"""
+    parser.addoption(
+        "--visualize",
+        action="store_true",
+        default=False,
+        help="Enable visualization during tests",
+    )

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -3,7 +3,7 @@ import open3d as o3d
 import camtools as ct
 
 
-def test_mesh_to_depth():
+def test_mesh_to_depth(visualize: bool = True):
     # Geometries
     sphere = o3d.geometry.TriangleMesh.create_sphere(radius=1.0)
     sphere = sphere.translate([0, 0, 4])
@@ -28,7 +28,6 @@ def test_mesh_to_depth():
     points_to_mesh_distances = ct.solver.points_to_mesh_distances(points, mesh)
     assert np.max(points_to_mesh_distances) < 5e-3
 
-    visualize = False
     if visualize:
         import matplotlib.pyplot as plt
 

--- a/test/test_raycast.py
+++ b/test/test_raycast.py
@@ -3,7 +3,17 @@ import open3d as o3d
 import camtools as ct
 
 
-def test_mesh_to_depth(visualize: bool = True):
+def test_mesh_to_depth(visualize: bool):
+    """
+    Test raycasting from a 3D mesh to a depth image, and verify the accuracy by
+    projecting back to 3D points.
+
+    Example usage:
+        pytest -s test/test_raycast.py
+        pytest -s test/test_raycast.py --visualize
+
+    See conftest.py for more information on the visualize fixture.
+    """
     # Geometries
     sphere = o3d.geometry.TriangleMesh.create_sphere(radius=1.0)
     sphere = sphere.translate([0, 0, 4])

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -1,3 +1,4 @@
+import pytest
 from pathlib import Path
 import numpy as np
 import open3d as o3d
@@ -5,7 +6,16 @@ import camtools as ct
 import matplotlib.pyplot as plt
 
 
-def test_render_geometries(visualize=True):
+def test_render_geometries(visualize):
+    """
+    Test rendering of 3D geometries (sphere and box) using Open3D.
+
+    Example usage:
+        pytest -s test/test_render.py
+        pytest -s test/test_render.py --visualize
+
+    See conftest.py for more information on the visualize fixture.
+    """
     # Setup geometries: sphere (red), box (blue)
     sphere = o3d.geometry.TriangleMesh.create_sphere(radius=1.0, resolution=100)
     sphere = sphere.translate([0, 0, 4])

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+import numpy as np
+import open3d as o3d
+import camtools as ct
+import matplotlib.pyplot as plt
+
+
+def test_render_geometries(visualize=False):
+    # Setup geometries: sphere (red), box (blue)
+    sphere = o3d.geometry.TriangleMesh.create_sphere(radius=1.0, resolution=100)
+    sphere = sphere.translate([0, 0, 4])
+    sphere = sphere.paint_uniform_color([0.2, 0.4, 0.8])
+    sphere.compute_vertex_normals()
+    box = o3d.geometry.TriangleMesh.create_box(width=1.5, height=1.5, depth=1.5)
+    box = box.translate([0, 0, 4])
+    box = box.paint_uniform_color([0.8, 0.2, 0.2])
+    box.compute_vertex_normals()
+    mesh = sphere + box
+
+    # Setup camera
+    width, height = 640, 480
+    fx, fy = 500, 500
+    cx, cy = width / 2, height / 2
+    K = np.array([[fx, 0, cx], [0, fy, cy], [0, 0, 1]])
+    T = np.eye(4)
+    camera_frustum = ct.camera.create_camera_frustums([K], [T], size=1)
+
+    # Test render
+    im_rgb = ct.render.render_geometries(
+        geometries=[mesh],
+        K=K,
+        T=T,
+        height=height,
+        width=width,
+    )
+
+    # Heuristic checks of RGB rendering
+    assert im_rgb.shape == (height, width, 3), "Image has incorrect dimensions"
+    num_white_pixels = np.sum(
+        (im_rgb[:, :, 0] > 0.9) & (im_rgb[:, :, 1] > 0.9) & (im_rgb[:, :, 2] > 0.9)
+    )
+    num_blue_pixels = np.sum(
+        (im_rgb[:, :, 2] > 0.7) & (im_rgb[:, :, 0] < 0.3) & (im_rgb[:, :, 1] < 0.5)
+    )
+    num_red_pixels = np.sum(
+        (im_rgb[:, :, 0] > 0.7) & (im_rgb[:, :, 1] < 0.3) & (im_rgb[:, :, 2] < 0.5)
+    )
+    assert num_white_pixels > (height * width * 0.8), "Expected mostly white background"
+    assert num_blue_pixels > 100, "Expected blue pixels (sphere) not found"
+    assert num_red_pixels > 100, "Expected red pixels (box) not found"
+
+    # Visualization
+    if visualize:
+        plt.figure(figsize=(10, 7.5))
+        plt.imshow(im_rgb)
+        plt.show()
+        axes = o3d.geometry.TriangleMesh.create_coordinate_frame(size=1)
+        o3d.visualization.draw_geometries([mesh, camera_frustum, axes])

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -99,33 +99,51 @@ def test_render_geometries(visualize=True):
         np.mean(im_mask_diff_methods) < 0.01
     ), "Raycast and render depth masks differ significantly"
 
+    # Calculate depth differences for visualization
+    im_depth_diff_methods = np.abs(im_render_depth - im_raycast_depth)
+
+    # Get mask where both depth maps have valid values
+    im_depth_valid_overlap = (im_render_depth != np.inf) & (im_raycast_depth != np.inf)
+    assert np.allclose(
+        im_render_depth[im_depth_valid_overlap],
+        im_raycast_depth[im_depth_valid_overlap],
+        atol=0.1,
+        rtol=0.1,
+    ), "Render and raycast depth values differ significantly in overlapping regions"
+
     # Visualization
     if visualize:
-        plt.figure(figsize=(25, 7.5))
+        plt.figure(figsize=(30, 7.5))
 
         # RGB and depth images
-        plt.subplot(1, 5, 1)
+        plt.subplot(1, 6, 1)
         plt.imshow(im_render_rgb)
         plt.title("Render RGB")
 
-        plt.subplot(1, 5, 2)
+        plt.subplot(1, 6, 2)
         plt.imshow(im_render_depth, cmap="viridis")
         plt.colorbar(label="Depth")
         plt.title("Render Depth")
 
-        plt.subplot(1, 5, 3)
+        plt.subplot(1, 6, 3)
         plt.imshow(im_raycast_depth, cmap="viridis")
         plt.colorbar(label="Depth")
         plt.title("Raycast Depth")
 
         # Mask comparisons
-        plt.subplot(1, 5, 4)
+        plt.subplot(1, 6, 4)
         plt.imshow(im_mask_diff_render, cmap="gray")
         plt.title("RGB vs Render Depth Mask Diff")
 
-        plt.subplot(1, 5, 5)
+        plt.subplot(1, 6, 5)
         plt.imshow(im_mask_diff_methods, cmap="gray")
         plt.title("Render vs Raycast Depth Mask Diff")
+
+        # Depth value comparison
+        plt.subplot(1, 6, 6)
+        plt.imshow(im_depth_diff_methods, cmap="viridis")
+        plt.colorbar(label="Depth Difference")
+        plt.title("Depth Difference (Norm")
 
         plt.tight_layout()
         plt.show()

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -6,18 +6,7 @@ import camtools as ct
 import matplotlib.pyplot as plt
 
 
-def _has_display():
-    """Check if display is available for Open3D visualization."""
-    try:
-        # Try to create a visualizer to check if display is available
-        vis = o3d.visualization.Visualizer()
-        vis.destroy_window()
-        return True
-    except Exception:
-        return False
-
-
-@pytest.mark.skipif(not _has_display(), reason="No display available for Open3D")
+@pytest.mark.skip_no_display
 def test_render_geometries(visualize: bool):
     """
     Test rendering of 3D geometries (sphere and box) using Open3D.

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -6,7 +6,7 @@ import camtools as ct
 import matplotlib.pyplot as plt
 
 
-def test_render_geometries(visualize):
+def test_render_geometries(visualize: bool):
     """
     Test rendering of 3D geometries (sphere and box) using Open3D.
 

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -118,29 +118,29 @@ def test_render_geometries(visualize=True):
         # RGB and depth images
         plt.subplot(1, 6, 1)
         plt.imshow(im_render_rgb)
-        plt.title("im_render_rgb")
+        plt.title("Rendered RGB")
 
         plt.subplot(1, 6, 2)
         plt.imshow(im_render_depth, cmap="viridis")
-        plt.title("im_render_depth")
+        plt.title("Rendered Depth")
 
         plt.subplot(1, 6, 3)
         plt.imshow(im_raycast_depth, cmap="viridis")
-        plt.title("im_raycast_depth")
+        plt.title("Raycast Depth")
 
         # Mask comparisons
         plt.subplot(1, 6, 4)
         plt.imshow(im_mask_diff_rgb_vs_render, cmap="gray")
-        plt.title("im_mask_diff_rgb_vs_render")
+        plt.title("Mask: Rendered RGB vs Rendered Depth")
 
         plt.subplot(1, 6, 5)
         plt.imshow(im_mask_diff_raycast_vs_render, cmap="gray")
-        plt.title("Render vs Raycast Depth Mask Diff")
+        plt.title("Mask: Raycast Depth vs Rendered Depth")
 
         # Depth value comparison
         plt.subplot(1, 6, 6)
         plt.imshow(im_depth_diff_methods, cmap="viridis")
-        plt.title("Depth Difference (L1 Norm)")
+        plt.title("Rendered Depth vs Raycast Depth (L1 Norm)")
 
         plt.tight_layout()
         plt.show()

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -6,8 +6,7 @@ import camtools as ct
 import matplotlib.pyplot as plt
 
 
-@pytest.fixture
-def has_display():
+def _has_display():
     """Check if display is available for Open3D visualization."""
     try:
         # Try to create a visualizer to check if display is available
@@ -18,7 +17,7 @@ def has_display():
         return False
 
 
-@pytest.mark.skipif(not has_display(), reason="No display available for Open3D")
+@pytest.mark.skipif(not _has_display(), reason="No display available for Open3D")
 def test_render_geometries(visualize: bool):
     """
     Test rendering of 3D geometries (sphere and box) using Open3D.

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -6,19 +6,7 @@ import camtools as ct
 import matplotlib.pyplot as plt
 
 
-@pytest.fixture
-def has_display():
-    """Check if display is available for Open3D visualization."""
-    try:
-        # Try to create a visualizer to check if display is available
-        vis = o3d.visualization.Visualizer()
-        vis.destroy_window()
-        return True
-    except Exception:
-        return False
-
-
-@pytest.mark.skipif(not has_display(), reason="No display available for Open3D")
+@pytest.mark.skipif(not pytest.has_display(), reason="No display available")
 def test_render_geometries(visualize: bool):
     """
     Test rendering of 3D geometries (sphere and box) using Open3D.

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -6,7 +6,19 @@ import camtools as ct
 import matplotlib.pyplot as plt
 
 
-@pytest.mark.skipif(not pytest.has_display(), reason="No display available")
+@pytest.fixture
+def has_display():
+    """Check if display is available for Open3D visualization."""
+    try:
+        # Try to create a visualizer to check if display is available
+        vis = o3d.visualization.Visualizer()
+        vis.destroy_window()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not has_display(), reason="No display available for Open3D")
 def test_render_geometries(visualize: bool):
     """
     Test rendering of 3D geometries (sphere and box) using Open3D.

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -6,7 +6,7 @@ import camtools as ct
 import matplotlib.pyplot as plt
 
 
-@pytest.mark.skip_no_display
+@pytest.mark.skip_no_o3d_display
 def test_render_geometries(visualize: bool):
     """
     Test rendering of 3D geometries (sphere and box) using Open3D.

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -6,6 +6,19 @@ import camtools as ct
 import matplotlib.pyplot as plt
 
 
+@pytest.fixture
+def has_display():
+    """Check if display is available for Open3D visualization."""
+    try:
+        # Try to create a visualizer to check if display is available
+        vis = o3d.visualization.Visualizer()
+        vis.destroy_window()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not has_display(), reason="No display available for Open3D")
 def test_render_geometries(visualize: bool):
     """
     Test rendering of 3D geometries (sphere and box) using Open3D.

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -75,6 +75,10 @@ def test_render_geometries(visualize=True):
     im_raycast_mask = im_raycast_depth != np.inf  # Invalid depth is set to inf
     im_render_mask = im_render_depth > 0  # Invalid depth is set to 0
 
+    # For raycast depth, the invalid depth is inf. For render depth, the invalid
+    # depth is 0, so we set it to inf for visualization consistency.
+    im_render_depth[im_render_depth == 0] = np.inf
+
     # Compare masks
     im_mask_diff_raycast = np.abs(
         im_rgb_mask.astype(float) - im_raycast_mask.astype(float)


### PR DESCRIPTION
### Summary
This pull request introduces comprehensive testing for the rendering functionality in `camtools`, including new test cases for rendering geometries and depth images. It also adds a visualization control mechanism via a pytest fixture to enable or disable visualization during test execution.

### Context
The rendering functionality in `camtools` needed more robust testing to ensure accuracy and consistency, particularly when rendering depth images. Additionally, the ability to control visualization during tests was required to facilitate debugging and validation without cluttering the test output.

### Changes Made
- **Added `test_render.py`**: Introduced new test cases to verify the rendering of 3D geometries (sphere and box) using Open3D, including RGB and depth image rendering.
- **Added `conftest.py`**: Implemented a pytest fixture `visualize` to control visualization during tests, which can be enabled via the command line with `--visualize`.
- **Modified `render.py`**: Updated the docstring to clarify that invalid or infinite depth values are set to 0 during rendering.
- **Modified `test_raycast.py`**: Refactored the `test_mesh_to_depth` function to include the `visualize` parameter for better control over visualization.

### Testing Details
- **Test Scenarios**: The new tests cover rendering of RGB and depth images, comparison between rendered and raycast depth images, and validation of depth values in overlapping regions.
- **Visualization**: Visualization can be enabled with the `--visualize` flag, which displays RGB and depth images, mask comparisons, and depth value differences.
- **Assertions**: Added assertions to verify image dimensions, pixel color distributions, and depth value consistency between rendering and raycasting methods.

### Example
```bash
pytest -s test/test_render.py --visualize
```
This will generate:
![Figure_1](https://github.com/user-attachments/assets/24caafad-c140-4475-8970-26088bb6933e)
, which is rendered from this scene & camera:
![ScreenCapture_2024-12-27-16-51-00](https://github.com/user-attachments/assets/6f09dd90-ddee-43c0-a9ec-05219c158afd)
