### PR TITLE
docs: improve documentation sidebar UI 

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,18 @@
+/* Force toctree to stay expanded */
+.toctree-checkbox {
+    display: none !important;
+}
+
+.toctree-l1 ul {
+    display: block !important;
+}
+
+/* Hide the expand/collapse arrows */
+label[for^="toctree-checkbox-"] {
+    display: none !important;
+}
+
+/* Always show nested items */
+.sidebar-tree .toctree-l1>ul {
+    display: block !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,6 @@ html_theme_options = {
     "light_logo": "camtools_logo_light.png",
     "dark_logo": "camtools_logo_dark.png",
     "sidebar_hide_name": False,
-    "announcement": "<div style='text-align: left'>Hello</div>",
     "navigation_with_keys": True,
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,11 @@ language = "en"
 html_theme = "furo"
 html_static_path = ["_static", "../camtools/assets"]
 
+# Add custom CSS
+html_css_files = [
+    "custom.css",
+]
+
 # Get script directory
 script_dir = Path(__file__).parent
 
@@ -64,6 +69,7 @@ html_theme_options = {
     "dark_logo": "camtools_logo_dark.png",
     "sidebar_hide_name": False,
     "announcement": "<div style='text-align: left'>Hello</div>",
+    "navigation_with_keys": True,
 }
 
 # Set the title with version and git hash

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,8 @@ script_dir = Path(__file__).parent
 html_theme_options = {
     "light_logo": "camtools_logo_light.png",
     "dark_logo": "camtools_logo_dark.png",
+    "sidebar_hide_name": False,
+    "announcement": "<div style='text-align: left'>Hello</div>",
 }
 
 # Set the title with version and git hash

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,8 +71,9 @@ html_theme_options = {
     "navigation_with_keys": True,
 }
 
-# Set the title with version and git hash
-html_title = f"CamTools Documentation ({release})"
+# Set the title without version
+# This is the tab name in the browser
+html_title = "CamTools Documentation"
 
 # Favicon
 favicon_path = (
@@ -83,13 +84,13 @@ if not favicon_path.is_file():
 html_favicon = str(favicon_path)
 
 
-# Google Analytics configuration
 def add_ga_javascript(app, pagename, templatename, context, doctree):
     """
     Ref: https://github.com/sphinx-contrib/googleanalytics/blob/master/sphinxcontrib/googleanalytics.py
     """
     metatags = context.get("metatags", "")
-    metatags += """
+    metatags += (
+        """
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-FG59NQBWRW"></script>
     <script>
@@ -98,7 +99,18 @@ def add_ga_javascript(app, pagename, templatename, context, doctree):
         gtag('js', new Date());
         gtag('config', 'G-FG59NQBWRW');
     </script>
+    <!-- Update sidebar text -->
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const sidebarText = document.querySelector('.sidebar-brand-text');
+            if (sidebarText) {
+                sidebarText.textContent = 'CamTools Documentation (%s)';
+            }
+        });
+    </script>
     """
+        % release
+    )
     context["metatags"] = metatags
 
 


### PR DESCRIPTION
- The sidebar now shows the build number while the title does not
- The toctree for API docs is expanded by default