### PR TITLE
build: relax open3d and numpy version requirements

### DIFF
--- a/camtools/__init__.py
+++ b/camtools/__init__.py
@@ -39,6 +39,7 @@ __version__ = _get_package_version("camtools")
 
 
 # Check open3d and numpy compatibility
+# https://github.com/isl-org/Open3D/issues/6840
 try:
     logging.basicConfig(format="%(message)s")
     _logger = logging.getLogger(__name__)

--- a/camtools/__init__.py
+++ b/camtools/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from . import artifact
 from . import camera
 from . import colmap
@@ -16,13 +18,42 @@ from . import solver
 from . import transform
 from . import util
 
+
+# Get package version for camtools
 try:
     # Python >= 3.8
     from importlib.metadata import version
 
-    __version__ = version("camtools")
+    def _get_package_version(package):
+        return version(package)
+
 except ImportError:
     # Python < 3.8
     import pkg_resources
 
-    __version__ = pkg_resources.get_distribution("camtools").version
+    def _get_package_version(package):
+        return pkg_resources.get_distribution(package).version
+
+
+__version__ = _get_package_version("camtools")
+
+
+# Check open3d and numpy compatibility
+try:
+    logging.basicConfig(format="%(message)s")
+    _logger = logging.getLogger(__name__)
+
+    o3d_version = _get_package_version("open3d")
+    np_version = _get_package_version("numpy")
+
+    o3d_version_tuple = tuple(map(int, o3d_version.split(".")[:2]))
+    np_version_tuple = tuple(map(int, np_version.split(".")[:2]))
+
+    if o3d_version_tuple < (0, 19) and np_version_tuple >= (2, 0):
+        _logger.warning(
+            f"[Warning] Incompatible versions: open3d {o3d_version} does "
+            f"not support numpy {np_version}. You may upgrade open3d to >= 0.19.0 "
+            f"or downgrade numpy to 1.x."
+        )
+except Exception as e:
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 dependencies = [
-  "numpy>=1.15.0,<=1.26.4",
+  "numpy>=1.15.0",
   "open3d>=0.16.0",
   "opencv-python>=4.5.1.48",
   "matplotlib>=3.3.4",


### PR DESCRIPTION
Open3D >= 0.19.0 has fixed support for NumPy 2.x ([Open3D issue #6840](https://github.com/isl-org/Open3D/issues/6840)). This PR relaxes the version requirements for Open3D and NumPy. The user is responsible for ensuring the versions are compatible. We also provide a runtime check that will print out a warning message if Open3D and NumPy are not compatible.

## Compatibility test

`test_init.py`:
```python
import numpy as np
import open3d as o3d

print(f"Open3D version: {o3d.__version__}")
print(f"Numpy version: {np.__version__}")

mesh = o3d.geometry.TriangleMesh()
mesh.vertices = o3d.utility.Vector3dVector(np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]]))
print(f"Number of vertices: {len(mesh.vertices)}")
```

Results:
```bash
# Previous working case
$ python test_init.py                                                                              
Open3D version: 0.18.0                                                                                                                                  
Numpy version: 1.26.0                                                                                                                                   
Number of vertices: 3

# Incompatible case
$ python test_init.py                                                                              
Open3D version: 0.18.0                                                                                                                                  
Numpy version: 2.2.1                                                                                                                                    
[1]    1844774 segmentation fault  python test_init.py 

# New working case
$ python test_init.py  
Open3D version: 0.19.0
Numpy version: 2.2.1
Number of vertices: 3
```