### PR TITLE
fix(crop_borders): typo fix crop_boarders to crop_borders

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ clear and easy-to-use APIs.
 5. Command-line tools `ct` (runs in terminal).
 
    ```bash
-   # Crop image boarders.
-   ct crop-boarders *.png --pad_pixel 10 --skip_cropped --same_crop
+   # Crop image borders.
+   ct crop-borders *.png --pad_pixel 10 --skip_cropped --same_crop
 
    # Draw synchronized bounding boxes interactively.
    ct draw-bboxes path/to/a.png path/to/b.png

--- a/camtools/image.py
+++ b/camtools/image.py
@@ -10,7 +10,7 @@ from typing import Tuple, List, Optional, Union, Literal
 from jaxtyping import Float, UInt8, UInt16, Int
 
 
-def crop_white_boarders(
+def crop_white_borders(
     im: Float[np.ndarray, "h w 3"], padding: Tuple[int, int, int, int] = (0, 0, 0, 0)
 ) -> Float[np.ndarray, "h_cropped w_cropped 3"]:
     """

--- a/camtools/tools/__init__.py
+++ b/camtools/tools/__init__.py
@@ -1,3 +1,3 @@
-from . import crop_boarders
+from . import crop_borders
 from . import draw_bboxes
 from . import compress_images

--- a/camtools/tools/cli.py
+++ b/camtools/tools/cli.py
@@ -24,17 +24,17 @@ def main():
         help="Select one of these commands.\n\n",
     )
 
-    # ct crop-boarders
+    # ct crop-borders
     sub_parser = sub_parsers.add_parser(
-        "crop-boarders",
-        help="Crop boarders of images.\n"
+        "crop-borders",
+        help="Crop borders of images.\n"
         "```\n"
-        "ct crop-boarders *.png --pad_pixel 10 --skip_cropped --same_crop\n"
+        "ct crop-borders *.png --pad_pixel 10 --skip_cropped --same_crop\n"
         "```",
         formatter_class=argparse.RawTextHelpFormatter,
     )
-    sub_parser = ct.tools.crop_boarders.instantiate_parser(sub_parser)
-    sub_parser.set_defaults(func=ct.tools.crop_boarders.entry_point)
+    sub_parser = ct.tools.crop_borders.instantiate_parser(sub_parser)
+    sub_parser.set_defaults(func=ct.tools.crop_borders.entry_point)
 
     # ct draw-bboxes
     sub_parser = sub_parsers.add_parser(

--- a/camtools/tools/crop_borders.py
+++ b/camtools/tools/crop_borders.py
@@ -4,7 +4,7 @@ Crop white borders of an image.
 Example usage:
 
 ```python
-ct crop-boarders *.png --pad_pixel 10 --skip_cropped --same_crop
+ct crop-borders *.png --pad_pixel 10 --skip_cropped --same_crop
 ```
 """
 
@@ -128,7 +128,7 @@ def entry_point(parser, args):
 
         individual_croppings = ct.util.mt_loop(ct.image.compute_cropping, src_ims)
 
-        # Compute the minimum cropping boarders.
+        # Compute the minimum cropping borders.
         min_crop_u, min_crop_d, min_crop_l, min_crop_r = individual_croppings[0]
         for crop_u, crop_d, crop_l, crop_r in individual_croppings[1:]:
             min_crop_u = min(min_crop_u, crop_u)
@@ -145,7 +145,7 @@ def entry_point(parser, args):
             padding = int(max(h, w) * args.pad_ratio)
         paddings = [(padding, padding, padding, padding)] * len(src_ims)
     else:
-        # Compute cropping boarders.
+        # Compute cropping borders.
         croppings = ct.util.mt_loop(ct.image.compute_cropping, src_ims)
 
         # Compute paddings.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -131,8 +131,8 @@ The ``ct`` command runs in terminal:
 
 .. code-block:: bash
 
-   # Crop image boarders.
-   ct crop-boarders *.png --pad_pixel 10 --skip_cropped --same_crop
+   # Crop image borders.
+   ct crop-borders *.png --pad_pixel 10 --skip_cropped --same_crop
 
    # Draw synchronized bounding boxes interactively.
    ct draw-bboxes path/to/a.png path/to/b.png

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -33,10 +33,10 @@ def test_ct():
     )
 
 
-def test_crop_boarders():
+def test_crop_borders():
     _run_and_test_command(
-        cmd="ct crop-boarders --help",
-        required_stdout="usage: ct crop-boarders",
+        cmd="ct crop-borders --help",
+        required_stdout="usage: ct crop-borders",
     )
 
 


### PR DESCRIPTION
### Summary
This PR standardizes the naming convention across the codebase by renaming `crop_boarders` to `crop_borders`, ensuring consistency in both user-facing commands and internal API functions.

### Changes Made
- Renamed CLI command from `crop-boarders` to `crop-borders`
- Updated function name `crop_white_boarders` to `crop_white_borders` in `camtools/image.py`
- Renamed module file from `crop_boarders.py` to `crop_borders.py`
- Updated imports and references throughout the codebase including `README.md`, `docs/index.rst`, and tests
- Adjusted help text and example usages accordingly

### Breaking Changes
This change introduces a breaking change to the CLI interface and public API:
- Users must now use `ct crop-borders` instead of `ct crop-boarders`
- Any programmatic usage of `crop_white_boarders` should be updated to `crop_white_borders`